### PR TITLE
Fix typos, styles and add Button test

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -15,10 +15,19 @@ class Button extends Component {
   }
 
   isLinkInternal () {
-    if(this.props.link.indexOf("://") === -1)
-      return true;
+    if (!this.props.link)
+      return false;
 
-    return window.location.host === this.props.link.host;
+    if (this.props.link.indexOf('://') === -1) {
+      return true;
+    }
+
+    try {
+      const url = new URL(this.props.link);
+      return window.location && window.location.host === url.host;
+    } catch (e) {
+      return false;
+    }
   }
 
   render() {

--- a/components/PolarChart.js
+++ b/components/PolarChart.js
@@ -9,7 +9,7 @@ class PolarChart extends Component {
   static propTypes = {
     data: PropTypes.array.isRequired,
     caption: PropTypes.string,
-    firstRow: PropTypes.bool,
+    first: PropTypes.bool,
   }
 
   static defaultProps = {

--- a/components/ProjectIcon.js
+++ b/components/ProjectIcon.js
@@ -103,7 +103,7 @@ class ProjectIcon extends Component {
           contentLabel="Modal">
           <div>
             <button onClick={this.hideModal} className={"modal-close-button"}>
-              <img src={close} alt={"close button"} style={{border: 0, height: '1,5em', width: '1,5em', background: '#FAFAFA'}}/>
+              <img src={close} alt={"close button"} style={{border: 0, height: '1.5em', width: '1.5em', background: '#FAFAFA'}}/>
             </button>
             <h2>{this.props.title}</h2>
             <div className="modal-content">

--- a/components/__tests__/Button.test.js
+++ b/components/__tests__/Button.test.js
@@ -1,0 +1,28 @@
+import Button from '../Button';
+
+describe('Button.isLinkInternal', () => {
+  const originalLocation = window.location;
+  beforeEach(() => {
+    delete window.location;
+    window.location = { host: 'example.com' };
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+  });
+
+  test('returns true for relative links', () => {
+    const btn = new Button({ label: 'Test', link: '/about', color: 'green' });
+    expect(btn.isLinkInternal()).toBe(true);
+  });
+
+  test('returns true for same host links', () => {
+    const btn = new Button({ label: 'Test', link: 'https://example.com/page', color: 'green' });
+    expect(btn.isLinkInternal()).toBe(true);
+  });
+
+  test('returns false for external links', () => {
+    const btn = new Button({ label: 'Test', link: 'https://other.com', color: 'green' });
+    expect(btn.isLinkInternal()).toBe(false);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "export": "next export",
     "clearCache": "rimraf node_modules/.cache",
-    "deploy": "rimraf node_modules/.cache && next build && next export && type nul >> out/.nojekyll && git add out/ && git commit -m \"Deploy Next.js to harritaito.github.io\" && git subtree push --prefix out origin master"
+    "deploy": "rimraf node_modules/.cache && next build && next export && type nul >> out/.nojekyll && git add out/ && git commit -m \"Deploy Next.js to harritaito.github.io\" && git subtree push --prefix out origin master",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -43,6 +44,8 @@
     "victory": "^33.1.7"
   },
   "devDependencies": {
-    "babel-plugin-inline-import-data-uri": "^1.0.1"
+    "babel-jest": "^29.0.0",
+    "babel-plugin-inline-import-data-uri": "^1.0.1",
+    "jest": "^29.0.0"
   }
 }

--- a/pages/aikakone.js
+++ b/pages/aikakone.js
@@ -54,7 +54,7 @@ class Aikakone extends Component {
     let steps = [
       {
         title: "Canvas sessions & Research",
-        processes: ["Including but not limited to:", "Business approach", "Existing Solutions", "Academic studys", "Contextual inquiry", "User Research", "Semi-structured Interviews"]
+        processes: ["Including but not limited to:", "Business approach", "Existing Solutions", "Academic studies", "Contextual inquiry", "User Research", "Semi-structured Interviews"]
       },
       {
         title: "Design",
@@ -91,7 +91,7 @@ class Aikakone extends Component {
                     }/>
                     <Row content={
                       <p className={pStyle}>
-                        In University of Tampere's & Futurice's, Let’s Re-Design Health Services -course, the client company Espericare ltd, specialized on care and housing services, gave the course attendees task of creating some kind of entertainment service for stimulus purposes for their residents who have different severe conditions of memory deceases. The workshop course organized students into randomized teams that would design service concepts to present at the end of the course.
+                        In University of Tampere's & Futurice's, Let’s Re-Design Health Services -course, the client company Espericare ltd, specialized on care and housing services, gave the course attendees task of creating some kind of entertainment service for stimulus purposes for their residents who have different severe conditions of memory diseases. The workshop course organized students into randomized teams that would design service concepts to present at the end of the course.
                       </p>
                     }/>
                     <Row content={

--- a/static/README.md
+++ b/static/README.md
@@ -1,12 +1,9 @@
 # STATIC
 
 This directory contains your static files.
-Each file inside this directory is mapped to /.
+Each file inside this directory is mapped to /. For example, `/static/robots.txt` will be served as `/robots.txt`.
 
-Example: /static/robots.txt is mapped as /robots.txt.
+More information about static file serving in Next.js can be found in the documentation:
+https://nextjs.org/docs/basic-features/static-file-serving
 
-More information about the usage of this directory in the documentation:
-https://nuxtjs.org/guide/assets#static
-
-**This directory is not required, you can delete it if you don't want to use it.**
-
+**This directory is not required; you can delete it if you don't want to use it.**


### PR DESCRIPTION
## Summary
- correct typos on the Aikakone project page
- unify `first` prop in `PolarChart`
- fix decimal notation in `ProjectIcon` close button
- improve static README to mention Next.js
- add utility tests for `Button.isLinkInternal`
- set up Jest configuration
- adjust `isLinkInternal` implementation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858705d022c8330a1bdc6c00060e7d7