### PR TITLE
Fix build failure with newer Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # harritaito.github.io
+
+This repository contains the source for Harri Halonen's portfolio site built with Next.js.

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
-module.exports = {
-  exportPathMap: function () {
+const withBabelMinify = require('next-babel-minify')()
+
+module.exports = withBabelMinify({
+  exportPathMap() {
     return {
       '/': { page: '/' },
       '/about': { page: '/about' },
@@ -7,6 +9,4 @@ module.exports = {
       '/aikakone': { page: '/aikakone' }
     }
   }
-}
-const withBabelMinify = require('next-babel-minify')()
-module.exports = withBabelMinify()
+})

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "description": "portfolio of Harri Halonen",
   "scripts": {
     "dev": "next",
-    "build": "next build",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider next build",
     "start": "next start",
     "export": "next export",
     "clearCache": "rimraf node_modules/.cache",
-    "deploy": "rimraf node_modules/.cache && next build && next export && type nul >> out/.nojekyll && git add out/ && git commit -m \"Deploy Next.js to harritaito.github.io\" && git subtree push --prefix out origin master"
+    "deploy": "rimraf node_modules/.cache && NODE_OPTIONS=--openssl-legacy-provider next build && next export && type nul >> out/.nojekyll && git add out/ && git commit -m \"Deploy Next.js to harritaito.github.io\" && git subtree push --prefix out origin master"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- update build and deploy scripts to set `NODE_OPTIONS=--openssl-legacy-provider`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858705d3c5083308555858d9a1b1f3d