### PR TITLE
Upgrade to modern Next.js setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This portfolio highlights design and development projects and shares background 
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) 12 or newer (includes `npm`)
+- [Node.js](https://nodejs.org/) 18 or newer (includes `npm`)
 
 ## Local development
 

--- a/components/Lightbox.js
+++ b/components/Lightbox.js
@@ -12,10 +12,12 @@ class Lightbox extends Component {
   }
 
   
-  componentWillReceiveProps (nextProps) {
-    this.setState ({
-      modalIsOpen: nextProps.open
-    });
+  componentDidUpdate(prevProps) {
+    if (prevProps.open !== this.props.open) {
+      this.setState({
+        modalIsOpen: this.props.open
+      });
+    }
   }
 
 

--- a/components/Video.js
+++ b/components/Video.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 
 class Video extends Component {
 
-  componentWillReceiveProps(nextProps) {
-    nextProps.autoplay ? this.playVideo() : this.stopVideo();
+  componentDidUpdate(prevProps) {
+    if (prevProps.autoplay !== this.props.autoplay) {
+      this.props.autoplay ? this.playVideo() : this.stopVideo();
+    }
   }
 
   static propTypes = {

--- a/components/__tests__/Lightbox.test.js
+++ b/components/__tests__/Lightbox.test.js
@@ -1,0 +1,22 @@
+import Lightbox from '../Lightbox';
+
+describe('Lightbox componentDidUpdate', () => {
+  test('sets modal state when open prop changes', () => {
+    const lb = new Lightbox({ open: false, images: [] });
+    lb.state = { modalIsOpen: false };
+    lb.setState = jest.fn(function (state) { this.state = { ...this.state, ...state }; });
+    lb.props = { open: true, images: [] };
+    lb.componentDidUpdate({ open: false });
+    expect(lb.setState).toHaveBeenCalledWith({ modalIsOpen: true });
+    expect(lb.state.modalIsOpen).toBe(true);
+  });
+
+  test('does not update state when open unchanged', () => {
+    const lb = new Lightbox({ open: false, images: [] });
+    lb.state = { modalIsOpen: false };
+    lb.setState = jest.fn(function (state) { this.state = { ...this.state, ...state }; });
+    lb.props = { open: false, images: [] };
+    lb.componentDidUpdate({ open: false });
+    expect(lb.setState).not.toHaveBeenCalled();
+  });
+});

--- a/components/__tests__/Video.test.js
+++ b/components/__tests__/Video.test.js
@@ -1,0 +1,17 @@
+import Video from '../Video';
+
+describe('Video componentDidUpdate', () => {
+  test('plays and stops based on autoplay prop', () => {
+    const video = new Video({ autoplay: false, webMsrc: '', mp4src: '' });
+    const play = jest.fn();
+    const pause = jest.fn();
+    video._video = { play, pause };
+    video.props = { autoplay: true, webMsrc: '', mp4src: '' };
+    video.componentDidUpdate({ autoplay: false });
+    expect(play).toHaveBeenCalled();
+
+    video.props = { autoplay: false, webMsrc: '', mp4src: '' };
+    video.componentDidUpdate({ autoplay: true });
+    expect(pause).toHaveBeenCalled();
+  });
+});

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,4 @@
-const withBabelMinify = require('next-babel-minify')()
-
-module.exports = withBabelMinify({
+module.exports = {
   exportPathMap() {
     return {
       '/': { page: '/' },
@@ -9,4 +7,4 @@ module.exports = withBabelMinify({
       '/aikakone': { page: '/aikakone' }
     }
   }
-})
+}

--- a/package.json
+++ b/package.json
@@ -21,31 +21,33 @@
   ],
   "author": "Harri Halonen",
   "license": "ISC",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
-    "fontfaceobserver": "^2.1.0",
-    "next": "^9.1.7",
-    "next-babel-minify": "^1.0.0",
-    "next-images": "^1.3.0",
-    "react": "^16.12.0",
-    "react-collapse": "^4.0.3",
-    "react-dom": "^16.12.0",
-    "react-headroom": "^2.2.8",
+    "fontfaceobserver": "^2.3.0",
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-collapse": "^5.1.0",
+    "react-dom": "^18.2.0",
+    "react-headroom": "^3.1.0",
     "react-image": "^2.2.2",
-    "react-images": "^1.0.0",
-    "react-inlinesvg": "^1.2.0",
-    "react-medium-image-zoom": "^3.1.2",
-    "react-modal": "^3.11.1",
+    "react-images": "^1.3.1",
+    "react-inlinesvg": "^2.4.0",
+    "react-medium-image-zoom": "^4.3.1",
+    "react-modal": "^3.16.1",
     "react-motion": "^0.5.2",
     "react-plx": "^1.3.14",
     "react-reading-progress": "^0.3.0",
-    "react-reveal": "^1.2.2",
+    "react-reveal": "^2.2.0",
     "react-visibility-sensor": "^5.1.1",
-    "styled-jsx": "^3.2.4",
-    "victory": "^33.1.7"
+    "styled-jsx": "^5.1.0",
+    "victory": "^36.4.0"
   },
   "devDependencies": {
-    "babel-jest": "^29.0.0",
+    "babel-jest": "^29.7.0",
     "babel-plugin-inline-import-data-uri": "^1.0.1",
-    "jest": "^29.0.0"
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,12 +1,10 @@
-import Document, {Head, Main, NextScript } from 'next/document';
-import flush from 'styled-jsx/server';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import Fonts from '../components/Fonts';
 
 export default class MyDocument extends Document {
-  static getInitialProps({ renderPage }) {
-    const { html, head, errorHtml, chunks } = renderPage();
-    const styles = flush();
-    return { html, head, errorHtml, chunks, styles };
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
   }
   componentDidMount () {
     Fonts();
@@ -19,7 +17,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <html lang="en">
+      <Html lang="en">
         <Head>
             <meta charSet="UTF-8" />
             <meta httpEquiv="Cache-Control: max-age=86400" content="public" />
@@ -1376,15 +1374,10 @@ export default class MyDocument extends Document {
 
             `}</style>
         </Head>
-        <div id="root">
         <body>
             {this.props.customValue}
             <noscript>Sorry! You'll need to enable JavaScript to see my site.</noscript>
             <Main />
             <NextScript />
         </body>
-        </div>
-      </html>
-    )
-  }
-}
+      </Html>


### PR DESCRIPTION
## Summary
- update package versions for Next.js 14 and React 18
- drop next-babel-minify wrapper from config
- add Node >=18 engines field and jsdom test environment
- swap deprecated lifecycle methods with componentDidUpdate
- refresh custom Document implementation
- clarify Node requirement in README
- add unit tests for Lightbox and Video components

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0f98ecc48330baf38caafbcbf285