### PR TITLE
Switch carousel to react-responsive-carousel

### DIFF
--- a/components/Lightbox.js
+++ b/components/Lightbox.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import Carousel, { Modal, ModalGateway } from 'react-images';
+import { Carousel } from 'react-responsive-carousel';
 
 class Lightbox extends Component {
 
@@ -24,7 +24,14 @@ class Lightbox extends Component {
   render () {
     return (
       <div className="lightbox">
-        <Carousel views={this.props.images}/>
+        <Carousel showThumbs={false} showStatus={false}>
+          {this.props.images.map((img, i) => (
+            <div key={i}>
+              <img src={img.src} alt={img.caption || ''} />
+              {img.caption && <p className="legend">{img.caption}</p>}
+            </div>
+          ))}
+        </Carousel>
       </div>
     );
   }

--- a/components/__tests__/Lightbox.test.js
+++ b/components/__tests__/Lightbox.test.js
@@ -1,12 +1,11 @@
 import Lightbox from '../Lightbox';
 
-// Mock react-images to avoid DOM dependencies in tests
-jest.mock('react-images', () => {
+// Mock carousel library to avoid DOM dependencies in tests
+jest.mock('react-responsive-carousel', () => {
   const React = require('react');
-  const Carousel = () => React.createElement('div');
-  const Modal = (props) => React.createElement('div', props);
-  const ModalGateway = ({ children }) => React.createElement('div', null, children);
-  return { __esModule: true, default: Carousel, Modal, ModalGateway };
+  return {
+    Carousel: () => React.createElement('div'),
+  };
 });
 
 describe('Lightbox componentDidUpdate', () => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import Fonts from "../components/Fonts";
+import "react-responsive-carousel/lib/styles/carousel.min.css";
 
 function MyApp({ Component, pageProps }) {
   useEffect(() => {

--- a/pages/aikakone.js
+++ b/pages/aikakone.js
@@ -7,7 +7,8 @@ import Process from "../components/Process";
 import ProjectStats from "../components/ProjectStats";
 import ProjectSection from "../components/ProjectSection";
 import Row from "../components/Row";
-import Carousel, { Modal, ModalGateway } from "react-images";
+import { Carousel } from "react-responsive-carousel";
+import Modal from "react-modal";
 
 import hero from "../static/media/aikakone/hero.jpg";
 
@@ -412,33 +413,28 @@ class Aikakone extends Component {
                       }
                     />
 
-                    <ModalGateway>
-                      {modalIsOpen ? (
-                        <Modal onClose={this.toggleModal}>
-                          <Carousel
-                            views={[
-                              {
-                                src: menu,
-                                caption: "First look of the menu of Aikakone.",
-                              },
-                              {
-                                src: aikakone,
-                                caption: "Using Aikakone",
-                              },
-                              {
-                                src: profile,
-                                caption: "Profile of elderly people",
-                              },
-                              {
-                                src: elamankaari,
-                                caption:
-                                  "Elämänkaari, a feature that has the lifespan of induvidual user",
-                              },
-                            ]}
-                          />
-                        </Modal>
-                      ) : null}
-                    </ModalGateway>
+                    {modalIsOpen ? (
+                      <Modal isOpen={modalIsOpen} onRequestClose={this.toggleModal}>
+                        <Carousel showThumbs={false} showStatus={false}>
+                          <div>
+                            <img src={menu} alt="First look of the menu of Aikakone." />
+                            <p className="legend">First look of the menu of Aikakone.</p>
+                          </div>
+                          <div>
+                            <img src={aikakone} alt="Using Aikakone" />
+                            <p className="legend">Using Aikakone</p>
+                          </div>
+                          <div>
+                            <img src={profile} alt="Profile of elderly people" />
+                            <p className="legend">Profile of elderly people</p>
+                          </div>
+                          <div>
+                            <img src={elamankaari} alt="Elämänkaari, a feature that has the lifespan of induvidual user" />
+                            <p className="legend">Elämänkaari, a feature that has the lifespan of induvidual user</p>
+                          </div>
+                        </Carousel>
+                      </Modal>
+                    ) : null}
 
                     <Row
                       className="one-margin-top col-md-offset-1 col-lg-offset-3"

--- a/pages/kivakaupunki.js
+++ b/pages/kivakaupunki.js
@@ -9,7 +9,8 @@ import Process from '../components/Process';
 import ProjectStats from '../components/ProjectStats';
 import ProjectSection from "../components/ProjectSection";
 import Row from '../components/Row';
-import Carousel, { Modal, ModalGateway } from 'react-images';
+import { Carousel } from 'react-responsive-carousel';
+import Modal from 'react-modal';
 
 import hero from '../static/media/kivakaupunki/hero.jpg';
 
@@ -222,39 +223,36 @@ class Kivakaupunki extends Component {
                       </p>
                     }/>
 
-                    <ModalGateway>
                     {modalIsOpen ? (
-                      <Modal onClose={this.toggleModal}>
-                        <Carousel views={[
-                        {
-                          src: phone,
-                          caption: 'Start greeting scene of app'
-
-                        },
-                        {
-                          src: phone_booth,
-                          caption: 'Location tagging by gps or by selecting and tapping.'
-                        },
-                        {
-                          src: physical,
-                          caption: 'Second screen, notice the return button'
-                        },
-                        {
-                          src: popup,
-                          caption: 'Comment categories'
-                        },
-                        {
-                          src: watch,
-                          caption: 'Comment input'
-                        },
-                        {
-                          src: footsteps,
-                          caption: 'Final thank you screen'
-                        }
-                      ]} />
+                      <Modal isOpen={modalIsOpen} onRequestClose={this.toggleModal}>
+                        <Carousel showThumbs={false} showStatus={false}>
+                          <div>
+                            <img src={phone} alt="Start greeting scene of app" />
+                            <p className="legend">Start greeting scene of app</p>
+                          </div>
+                          <div>
+                            <img src={phone_booth} alt="Location tagging by gps or by selecting and tapping." />
+                            <p className="legend">Location tagging by gps or by selecting and tapping.</p>
+                          </div>
+                          <div>
+                            <img src={physical} alt="Second screen, notice the return button" />
+                            <p className="legend">Second screen, notice the return button</p>
+                          </div>
+                          <div>
+                            <img src={popup} alt="Comment categories" />
+                            <p className="legend">Comment categories</p>
+                          </div>
+                          <div>
+                            <img src={watch} alt="Comment input" />
+                            <p className="legend">Comment input</p>
+                          </div>
+                          <div>
+                            <img src={footsteps} alt="Final thank you screen" />
+                            <p className="legend">Final thank you screen</p>
+                          </div>
+                        </Carousel>
                       </Modal>
                     ) : null}
-                    </ModalGateway>
 
                     <Row className="one-margin-top" content={views.map(function (image, index) {
                         return (

--- a/test-setup.js
+++ b/test-setup.js
@@ -7,7 +7,7 @@ if (typeof global.document === 'undefined') {
   };
 }
 if (typeof global.window === 'undefined') {
-  global.window = { location: { host: '' } };
+  global.window = { location: { host: 'localhost', protocol: 'https:' } };
 }
 
 if (typeof globalThis.performance === 'undefined') {


### PR DESCRIPTION
## Summary
- replace `react-images` uses with `react-responsive-carousel`
- adjust lightbox unit tests
- use `react-modal` for displaying the carousels
- import carousel styles globally
- tweak test setup to include protocol and host

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888a4a3d3988330ae833610c5f856f2