### PR TITLE
Deploy static build via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master, work]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          publish_branch: gh-pages
+

--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Tests execute in a lightweight Node environment defined in `test-setup.js` so
 
 ## Deployment
 
-Running `npm run deploy` builds the site, exports it to `out/`, creates a `.nojekyll` file and commits the folder. The script then pushes the contents of `out/` to the `master` branch using `git subtree` so the pages are available through GitHub Pages.
+The repository includes a GitHub Actions workflow (`.github/workflows/deploy.yml`) which builds the site and publishes the `out/` directory to the `gh-pages` branch. Configure GitHub Pages to serve from that branch so the published site always matches the latest static build.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish `out/`
- update deployment instructions in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688931dc26bc8330b97cc690510b8ff9