### PR TITLE
fix: guard button url check during ssr

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -24,7 +24,10 @@ class Button extends Component {
 
     try {
       const url = new URL(this.props.link);
-      return window.location && window.location.host === url.host;
+      if (typeof window === 'undefined' || !window.location) {
+        return false;
+      }
+      return window.location.host === url.host;
     } catch (e) {
       return false;
     }

--- a/components/__tests__/Button.test.js
+++ b/components/__tests__/Button.test.js
@@ -27,4 +27,16 @@ describe('Button.isLinkInternal', () => {
     const btn = new Button({ label: 'Test', link: 'https://other.com', color: 'green' });
     expect(btn.isLinkInternal()).toBe(false);
   });
+
+  test('returns false when window is undefined (SSR)', () => {
+    const originalWindow = global.window;
+    global.window = undefined;
+
+    try {
+      const btn = new Button({ label: 'Test', link: 'https://example.com', color: 'green' });
+      expect(btn.isLinkInternal()).toBe(false);
+    } finally {
+      global.window = originalWindow;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- guard `Button.isLinkInternal` against SSR environments by checking for `window` before comparing hostnames
- add a regression test ensuring the helper returns `false` when `window` is undefined

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8eba60064833099149c03f5d0122f