### PR TITLE
Soften home page messaging for passive opportunities

### DIFF
--- a/pages/Home.js
+++ b/pages/Home.js
@@ -59,28 +59,37 @@ class Home extends Component {
 
           <Row
             content={
-              <div className="col-xs-12 col-sm-8 col-md-9 col-lg-6 col-xl-6">
-                <div>
-                  Experience designer passionate about creating better customer
-                  insight, increasing business value and improving customer
-                  experience for every client. I believe in quick results
-                  withdrawn from user centered - hands on research and
-                  co-creation.
+              <div className="col-xs-12 col-sm-8 col-md-9 col-lg-6 col-xl-6 hero">
+                <p className="tagline">
+                  Product designer shaping research-led services with civic, health, and emerging tech teams.
+                </p>
+                <p className="hero-intro">
+                  I help cross-functional groups untangle complex problems, share what we learn in plain language, and steward experiences that feel considered.
+                </p>
+                <ul className="value-list">
+                  <li>
+                    <strong>Bring clarity:</strong> Facilitate discovery research and synthesis that highlight the needs behind the numbers.
+                  </li>
+                  <li>
+                    <strong>Prototype together:</strong> Explore flows, interactions, and service touchpoints alongside the people who rely on them.
+                  </li>
+                  <li>
+                    <strong>Support delivery:</strong> Maintain lightweight systems and rituals so teams can iterate with confidence.
+                  </li>
+                </ul>
+                <div className="cta-group">
+                  <a className="primary-cta" href="#case-studies">
+                    Browse selected work
+                  </a>
+                  <a className="secondary-cta" href="#product-impact">
+                    See how I collaborate
+                  </a>
                 </div>
-                <div style={{ marginTop: "1.5em" }}>
-                  You could say I'm on a quest to make technology delightful,
-                  intuitive, and accessible to everyone.
+                <div className="availability">
+                  Currently supporting teams full-time and welcoming thoughtful collaborations and conversations.
                 </div>
-                <div style={{ marginTop: "1.5em" }}>
-                  Scroll 👇 to see some highlighted projects.
-                </div>
-                <div style={{ marginTop: "1.5em" }}>
-                  Hope you enjoy this porfolio made with React and Next.js with
-                  JSX styles, it is my first crack at them and originally
-                  designed and made in 2018.
-                </div>
-                <div style={{ marginTop: "1.5em", marginBottom: "1.5em" }}>
-                  Want to learn about the person behind the work?{" "}
+                <div className="about-link">
+                  Curious about the person behind the work?{" "}
                   <Link href="/about" as="/about">
                     Get to know me.
                     <div
@@ -100,9 +109,65 @@ class Home extends Component {
             }
           />
         </div>
+        <Row
+          content={
+            <h2
+              className="col-xs-12 col-sm-10 col-md-9 col-lg-6 col-xl-6 section-heading"
+              id="product-impact"
+            >
+              How I support teams
+            </h2>
+          }
+        />
+        <Row
+          content={
+            <div className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 impact-grid">
+              <div className="impact-card">
+                <h3>Discovery to clarity</h3>
+                <p>
+                  Bring people together around real problems by planning research, synthesising insights, and framing opportunities with service maps and JTBD.
+                </p>
+              </div>
+              <div className="impact-card">
+                <h3>Prototype to proof</h3>
+                <p>
+                  Explore flows, interfaces, and content in quick cycles—testing with the communities we design for before committing to build.
+                </p>
+              </div>
+              <div className="impact-card">
+                <h3>Scale the craft</h3>
+                <p>
+                  Nurture design rituals, systems, and handoffs that help teams move with care, accessibility, and shared context.
+                </p>
+              </div>
+            </div>
+          }
+        />
+        <Row
+          content={
+            <div className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 toolkit">
+              Toolkit: discovery research, facilitation, information architecture, interaction design, design systems,
+              accessibility, analytics, experimentation.
+            </div>
+          }
+        />
+        <Row
+          content={
+            <h2 className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 section-heading" id="case-studies">
+              Selected case studies
+            </h2>
+          }
+        />
+        <Row
+          content={
+            <p className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 section-subheading">
+              A snapshot from collaborative work across public, healthcare, and emerging tech contexts.
+            </p>
+          }
+        />
         <Project
           title="HRI study"
-          description="Contextual inquiry study with interviews, affinity diagrams to figure out the interaction and bit of usability with a teaching assistant robot."
+          description="Led contextual inquiries, interviews, and usability studies to define how a teaching assistant robot should support classroom rituals and learning outcomes."
           image={languagerobot}
           link="/hri-study"
           alt="Application for city reporting"
@@ -111,7 +176,7 @@ class Home extends Component {
         />
         <Project
           title="Kiva Kaupunki"
-          description="From thoughts to action. Information of surroundings to city officials as well as for the public, so they can be even better."
+          description="Co-created a city feedback platform that turned citizen reporting into actionable insights for officials through service blueprints and iterative prototyping."
           image={kivakaupunki}
           link="/kivakaupunki"
           alt="Application for city reporting"
@@ -120,7 +185,7 @@ class Home extends Component {
         />
         <Project
           title="Aikakone"
-          description="Dementia/Alzheimer diseases increasing and growing concern about quality of health care systems. Nurses don’t have sufficient time to engage individually and it’s difficult to get patients excited in common activities."
+          description="Designed a reminiscence service for memory care by partnering with nurses and families, prototyping multi-sensory moments that improve engagement for people with dementia."
           image={aikakone}
           link="/aikakone"
           alt="Concept service for people with memory deseaces"
@@ -158,20 +223,10 @@ class Home extends Component {
                 "col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3 col-xl-4 col-xl-offset-4 contact"
               }
             >
-              Feel free to{" "}
-              <a href="mailto:harri@harritaito.com">
-                email me
-                <div
-                  style={{
-                    display: "block",
-                    height: 8,
-                    width: "98%",
-                    background: "rgba(139, 200, 246, 0.565)",
-                    marginTop: -9,
-                    marginLeft: 2,
-                  }}
-                />
-              </a>{" "}
+              I enjoy swapping notes with curious teams and researchers. If you'd like to connect, send a short hello to{" "}
+              <span className="obfuscated-email" aria-label="harri@harritaito.com">
+                harri [at] harritaito [dot] com
+              </span>{" "}
               or{" "}
               <a href={"https://calendly.com/harritaito/45min/"}>
                 book time on my calendar
@@ -185,8 +240,8 @@ class Home extends Component {
                     marginLeft: 2,
                   }}
                 />
-              </a>
-              .
+              </a>{" "}
+              when schedules align.
             </div>
           }
         />
@@ -208,6 +263,149 @@ class Home extends Component {
             }
           }
 
+          .Home .hero {
+            margin-top: 1.5em;
+          }
+
+          .Home .tagline {
+            font-size: 1.6em;
+            font-weight: 600;
+            line-height: 1.5;
+          }
+
+          @media only screen and (max-width: 45rem) {
+            .Home .tagline {
+              font-size: 1.4em;
+            }
+          }
+
+          .Home .hero-intro {
+            margin-top: 1.5em;
+            font-size: 1.05em;
+            line-height: 1.7;
+          }
+
+          .Home .value-list {
+            margin-top: 1.5em;
+            padding-left: 1.2em;
+            line-height: 1.7;
+          }
+
+          .Home .value-list li {
+            margin-bottom: 0.75em;
+          }
+
+          .Home .value-list li:last-child {
+            margin-bottom: 0;
+          }
+
+          .Home .cta-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1em;
+            margin-top: 2em;
+          }
+
+          .Home .primary-cta,
+          .Home .secondary-cta {
+            display: inline-block;
+            font-weight: 600;
+            text-decoration: none;
+            border-radius: 999px;
+            padding: 0.75em 1.5em;
+          }
+
+          .Home .primary-cta {
+            background: #1e95ed;
+            color: white;
+          }
+
+          .Home .primary-cta:hover,
+          .Home .primary-cta:focus {
+            background: #1475b9;
+          }
+
+          .Home .secondary-cta {
+            border: 2px solid rgba(30, 149, 237, 0.45);
+            color: inherit;
+          }
+
+          .Home .secondary-cta:hover,
+          .Home .secondary-cta:focus {
+            border-color: #1e95ed;
+            color: #1e95ed;
+          }
+
+          .Home .availability {
+            margin-top: 1.5em;
+            font-size: 0.95em;
+            font-weight: 600;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+          }
+
+          .Home .about-link {
+            margin-top: 1.5em;
+          }
+
+          .Home .section-heading {
+            margin-top: 5em;
+            margin-bottom: 0.5em;
+            font-size: 1.8em;
+            line-height: 1.4;
+          }
+
+          @media only screen and (max-width: 45rem) {
+            .Home .section-heading {
+              margin-top: 3em;
+            }
+          }
+
+          .Home .section-subheading {
+            margin-bottom: 2.5em;
+            line-height: 1.7;
+          }
+
+          .Home .impact-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.5em;
+            margin-top: 1em;
+          }
+
+          .Home .impact-card {
+            background: rgba(255, 255, 255, 0.88);
+            border-radius: 1.2rem;
+            box-shadow: 0 1em 2em 0 rgba(0, 0, 0, 0.12);
+            padding: 1.75em;
+            flex: 1 1 14rem;
+            min-width: 14rem;
+          }
+
+          .Home .impact-card h3 {
+            margin-top: 0;
+            margin-bottom: 0.75em;
+          }
+
+          .Home .impact-card p {
+            margin: 0;
+            line-height: 1.7;
+          }
+
+          .Home .toolkit {
+            margin-top: 1.5em;
+            line-height: 1.7;
+            font-size: 0.95em;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+          }
+
+          @media only screen and (max-width: 45rem) {
+            .Home .toolkit {
+              letter-spacing: 0.04em;
+            }
+          }
+
           .pohja {
             position: absolute;
             top: 0;
@@ -222,12 +420,12 @@ class Home extends Component {
 
           .Home .other-stuff {
             text-align: center;
-            margin-top: -1.5em;
+            margin-top: 5em;
             margin-bottom: 1.5em;
           }
           @media only screen and (max-width: 45rem) {
             .Home .other-stuff {
-              margin-top: -3.5em;
+              margin-top: 3em;
             }
           }
 
@@ -245,6 +443,24 @@ class Home extends Component {
 
           .Home .contact {
             text-align: center;
+          }
+
+          .Home .obfuscated-email {
+            display: inline-block;
+            font-weight: 600;
+            position: relative;
+            z-index: 0;
+          }
+
+          .Home .obfuscated-email::after {
+            content: "";
+            position: absolute;
+            left: 0;
+            bottom: 0.15em;
+            width: 100%;
+            height: 8px;
+            background: rgba(139, 200, 246, 0.565);
+            z-index: -1;
           }
 
           @media only screen and (max-width: 412px) {


### PR DESCRIPTION
## Summary
- retune the home hero copy to emphasize collaborative work while removing direct hiring CTAs
- refresh the impact and case study framing with gentler language aligned to an active full-time role
- update the contact section to obfuscate the email address and invite lighter-touch conversations

## Testing
- npm test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c7af7f388330a47dbcb76efb005a