### PR TITLE
fix: correct package dependency versions

### DIFF
--- a/docs/package-overview.md
+++ b/docs/package-overview.md
@@ -1,0 +1,24 @@
+# Package Overview
+
+This project is a Next.js portfolio site for Harri Halonen. The package metadata highlights:
+
+- **Scripts**
+  - `dev`: Runs the Next.js development server.
+  - `build`: Builds the production output and ensures GitHub Pages ignores Jekyll processing by touching `.nojekyll`.
+  - `start`: Serves the production build.
+  - `clearCache`: Removes the Next.js cache under `node_modules/.cache`.
+  - `deploy`: Builds the site, adds the `out/` directory to git, commits, and pushes a subtree to the `master` branch for deployment.
+  - `test`: Executes the Jest test suite.
+
+- **Dependencies**
+  - Core framework: `next` 15 and React 18.
+  - Media utilities: `react-medium-image-zoom`, `react-responsive-carousel`, `react-image`, and `react-inlinesvg`.
+  - UX enhancements: `react-headroom`, `react-modal`, `react-plx`, `react-visibility-sensor`, and `react-collapse`.
+  - Visualization: `victory` for charts.
+  - Font loading: `fontfaceobserver`.
+
+- **Tooling**
+  - Uses Jest with Babel for testing.
+  - Includes `next-babel-minify` for optimized builds and `next-images` for static asset handling.
+
+Overall, the configuration is tailored for a media-rich portfolio with attention to image handling, animations, and deployment to GitHub Pages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "fontfaceobserver": "^2.3.0",
-        "next": "^15.4.4",
+        "next": "^15.5.0",
         "next-images": "^1.8.5",
-        "react": "^18.2.0",
+        "react": "^18.3.1",
         "react-collapse": "^5.1.1",
-        "react-dom": "^18.2.0",
+        "react-dom": "^18.3.1",
         "react-headroom": "^3.2.1",
         "react-image": "^4.1.0",
         "react-inlinesvg": "^4.2.0",
@@ -31,7 +31,8 @@
         "babel-jest": "^30.0.4",
         "babel-plugin-inline-import-data-uri": "^1.0.1",
         "jest": "^30.0.4",
-        "jest-environment-jsdom": "^30.0.5"
+        "jest-environment-jsdom": "^30.0.5",
+        "rimraf": "^5.0.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1616,15 +1617,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.4.tgz",
-      "integrity": "sha512-SJKOOkULKENyHSYXE5+KiFU6itcIb6wSBjgM92meK0HVKpo94dNOLZVdLLuS7/BxImROkGoPsjR4EnuDucqiiA==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.5.tgz",
+      "integrity": "sha512-2Zhvss36s/yL+YSxD5ZL5dz5pI6ki1OLxYlh6O77VJ68sBnlUrl5YqhBgCy7FkdMsp9RBeGFwpuDCdpJOqdKeQ==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.4.tgz",
-      "integrity": "sha512-eVG55dnGwfUuG+TtnUCt+mEJ+8TGgul6nHEvdb8HEH7dmJIFYOCApAaFrIrxwtEq2Cdf+0m5sG1Np8cNpw9EAw==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.5.tgz",
+      "integrity": "sha512-lYExGHuFIHeOxf40mRLWoA84iY2sLELB23BV5FIDHhdJkN1LpRTPc1MDOawgTo5ifbM5dvAwnGuHyNm60G1+jw==",
       "cpu": [
         "arm64"
       ],
@@ -1638,9 +1639,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.4.tgz",
-      "integrity": "sha512-zqG+/8apsu49CltEj4NAmCGZvHcZbOOOsNoTVeIXphYWIbE4l6A/vuQHyqll0flU2o3dmYCXsBW5FmbrGDgljQ==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.5.tgz",
+      "integrity": "sha512-cacs/WQqa96IhqUm+7CY+z/0j9sW6X80KE07v3IAJuv+z0UNvJtKSlT/T1w1SpaQRa9l0wCYYZlRZUhUOvEVmg==",
       "cpu": [
         "x64"
       ],
@@ -1654,9 +1655,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.4.tgz",
-      "integrity": "sha512-LRD4l2lq4R+2QCHBQVC0wjxxkLlALGJCwigaJ5FSRSqnje+MRKHljQNZgDCaKUZQzO/TXxlmUdkZP/X3KNGZaw==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.5.tgz",
+      "integrity": "sha512-tLd90SvkRFik6LSfuYjcJEmwqcNEnVYVOyKTacSazya/SLlSwy/VYKsDE4GIzOBd+h3gW+FXqShc2XBavccHCg==",
       "cpu": [
         "arm64"
       ],
@@ -1670,9 +1671,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.4.tgz",
-      "integrity": "sha512-LsGUCTvuZ0690fFWerA4lnQvjkYg9gHo12A3wiPUR4kCxbx/d+SlwmonuTH2SWZI+RVGA9VL3N0S03WTYv6bYg==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.5.tgz",
+      "integrity": "sha512-ekV76G2R/l3nkvylkfy9jBSYHeB4QcJ7LdDseT6INnn1p51bmDS1eGoSoq+RxfQ7B1wt+Qa0pIl5aqcx0GLpbw==",
       "cpu": [
         "arm64"
       ],
@@ -1686,9 +1687,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.4.tgz",
-      "integrity": "sha512-aOy5yNRpLL3wNiJVkFYl6w22hdREERNjvegE6vvtix8LHRdsTHhWTpgvcYdCK7AIDCQW5ATmzr9XkPHvSoAnvg==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.5.tgz",
+      "integrity": "sha512-tI+sBu+3FmWtqlqD4xKJcj3KJtqbniLombKTE7/UWyyoHmOyAo3aZ7QcEHIOgInXOG1nt0rwh0KGmNbvSB0Djg==",
       "cpu": [
         "x64"
       ],
@@ -1702,9 +1703,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.4.tgz",
-      "integrity": "sha512-FL7OAn4UkR8hKQRGBmlHiHinzOb07tsfARdGh7v0Z0jEJ3sz8/7L5bR23ble9E6DZMabSStqlATHlSxv1fuzAg==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.5.tgz",
+      "integrity": "sha512-kDRh+epN/ulroNJLr+toDjN+/JClY5L+OAWjOrrKCI0qcKvTw9GBx7CU/rdA2bgi4WpZN3l0rf/3+b8rduEwrQ==",
       "cpu": [
         "x64"
       ],
@@ -1718,9 +1719,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.4.tgz",
-      "integrity": "sha512-eEdNW/TXwjYhOulQh0pffTMMItWVwKCQpbziSBmgBNFZIIRn2GTXrhrewevs8wP8KXWYMx8Z+mNU0X+AfvtrRg==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.5.tgz",
+      "integrity": "sha512-GDgdNPFFqiKjTrmfw01sMMRWhVN5wOCmFzPloxa7ksDfX6TZt62tAK986f0ZYqWpvDFqeBCLAzmgTURvtQBdgw==",
       "cpu": [
         "arm64"
       ],
@@ -1734,9 +1735,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.4.tgz",
-      "integrity": "sha512-SE5pYNbn/xZKMy1RE3pAs+4xD32OI4rY6mzJa4XUkp/ItZY+OMjIgilskmErt8ls/fVJ+Ihopi2QIeW6O3TrMw==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.5.tgz",
+      "integrity": "sha512-5kE3oRJxc7M8RmcTANP8RGoJkaYlwIiDD92gSwCjJY0+j8w8Sl1lvxgQ3bxfHY2KkHFai9tpy/Qx1saWV8eaJQ==",
       "cpu": [
         "x64"
       ],
@@ -5163,12 +5164,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.4.tgz",
-      "integrity": "sha512-kNcubvJjOL9yUOfwtZF3HfDhuhp+kVD+FM2A6Tyua1eI/xfmY4r/8ZS913MMz+oWKDlbps/dQOWdDricuIkXLw==",
+      "version": "15.5.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.5.tgz",
+      "integrity": "sha512-OQVdBPtpBfq7HxFN0kOVb7rXXOSIkt5lTzDJDGRBcOyVvNRIWFauMqi1gIHd1pszq1542vMOGY0HP4CaiALfkA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.4",
+        "@next/env": "15.5.5",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -5181,14 +5182,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.4",
-        "@next/swc-darwin-x64": "15.4.4",
-        "@next/swc-linux-arm64-gnu": "15.4.4",
-        "@next/swc-linux-arm64-musl": "15.4.4",
-        "@next/swc-linux-x64-gnu": "15.4.4",
-        "@next/swc-linux-x64-musl": "15.4.4",
-        "@next/swc-win32-arm64-msvc": "15.4.4",
-        "@next/swc-win32-x64-msvc": "15.4.4",
+        "@next/swc-darwin-arm64": "15.5.5",
+        "@next/swc-darwin-x64": "15.5.5",
+        "@next/swc-linux-arm64-gnu": "15.5.5",
+        "@next/swc-linux-arm64-musl": "15.5.5",
+        "@next/swc-linux-x64-gnu": "15.5.5",
+        "@next/swc-linux-x64-musl": "15.5.5",
+        "@next/swc-win32-arm64-msvc": "15.5.5",
+        "@next/swc-win32-x64-msvc": "15.5.5",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -5903,6 +5904,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   "license": "ISC",
   "dependencies": {
     "fontfaceobserver": "^2.3.0",
-    "next": "^15.4.4",
+    "next": "^15.5.0",
     "next-images": "^1.8.5",
-    "react": "^19.1.0",
+    "react": "^18.3.1",
     "react-collapse": "^5.1.1",
-    "react-dom": "^19.1.0",
+    "react-dom": "^18.3.1",
     "react-headroom": "^3.2.1",
     "react-image": "^4.1.0",
     "react-inlinesvg": "^4.2.0",
@@ -46,6 +46,7 @@
     "babel-jest": "^30.0.4",
     "babel-plugin-inline-import-data-uri": "^1.0.1",
     "jest": "^30.0.4",
-    "jest-environment-jsdom": "^30.0.5"
+    "jest-environment-jsdom": "^30.0.5",
+    "rimraf": "^5.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- align Next.js and React dependencies in the package manifest with supported versions
- add rimraf as a managed dependency for build scripts and refresh the lockfile

## Testing
- `npm test`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68f14b9afeac833089fca16fbe7f916c