### PR TITLE
fix: align publish script with gh-pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harritaito.github.io",
   "version": "1.0.1",
-  "homepage": "http://harritaito.com",
+  "homepage": "https://harritaito.com",
   "description": "portfolio of Harri Halonen",
   "scripts": {
     "dev": "next",
@@ -10,7 +10,7 @@
     "postbuild": "node scripts/create-nojekyll.js",
     "start": "next start",
     "clearCache": "rimraf node_modules/.cache",
-    "publish": "git add out/ && git commit -m \"Deploy Next.js to harritaito.github.io\" && git subtree push --prefix out origin master",
+    "publish": "git add out/ && git commit -m \"Deploy Next.js to harritaito.github.io\" && git subtree push --prefix out origin gh-pages",
     "deploy": "npm run build && npm run publish",
     "test": "jest"
   },


### PR DESCRIPTION
## Summary
- switch the documented homepage to HTTPS
- update the publish script to push the export to the gh-pages branch so it matches the workflow configuration

## Testing
- npm test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f14f0073208330bb4f99b31336c511