### PR TITLE
Ensure GitHub Pages serves Next.js assets

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll processing so Next.js assets in _next/ are served


### PR DESCRIPTION
## Summary
- add a .nojekyll marker so GitHub Pages serves the Next.js `_next` directory

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_690143ddc73883309636f6f2a365a1dc