### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,32 @@ Tests execute in a lightweight Node environment defined in `test-setup.js` so
 
 ## Deployment
 
+GitHub Pages respects the `.nojekyll` marker in the repository root. Keeping that file prevents Pages from stripping the `_next` directory that holds the statically exported JavaScript assets, so the published site continues to load styles and scripts correctly.
+
+### Publishing with GitHub Actions
+
 The repository includes a GitHub Actions workflow (`.github/workflows/deploy.yml`) which builds the site and publishes the `out/` directory to the `gh-pages` branch. Configure GitHub Pages to serve from that branch so the published site always matches the latest static build.
 
-To verify the static export before publishing, run the build locally and inspect the HTML under `out/`:
+1. Push your changes to the `main` branch.
+2. GitHub Actions will run the `deploy` workflow automatically and update the `gh-pages` branch with the latest static export.
+3. Confirm the deployment succeeded by checking the workflow run and visiting the configured Pages URL once it completes.
 
-```bash
-npm run build
-```
+Because GitHub Pages serves files exactly as they exist in the published branch, avoid deleting `.nojekyll` or the `CNAME` marker when updating the `gh-pages` branch—both files are required for the production site to resolve correctly.
 
-When you are satisfied with the build output you can publish the contents of `out/` to GitHub Pages directly from your workstation:
+### Publishing manually
 
-```bash
-npm run publish
-```
+If you need to publish without waiting for CI, verify the static export locally and push it yourself.
 
-The `publish` command keeps the `deploy` workflow's git subtree deployment for backwards compatibility while making it easy to separate the build and publishing steps when working locally.
+1. Run a production build and inspect the generated HTML under `out/`:
+
+   ```bash
+   npm run build
+   ```
+
+2. When you are satisfied with the build output, publish the contents of `out/` to GitHub Pages from your workstation:
+
+   ```bash
+   npm run publish
+   ```
+
+The `publish` command keeps the `deploy` workflow's git subtree deployment for backwards compatibility while making it easy to separate the build and publishing steps when working locally. Make sure you have permission to push to the `gh-pages` branch before running it.

--- a/components/Button.js
+++ b/components/Button.js
@@ -86,7 +86,7 @@ class Button extends Component {
           /* Outline Button Rules */
 
           .button.outline .button-link {
-            color: #696a6d;
+            color: var(--muted-text-color);
             padding: 0;
           }
 
@@ -97,7 +97,7 @@ class Button extends Component {
           }
 
           .button.outline .button-link::before {
-            border: 2px solid #696a6d;
+            border: 2px solid var(--muted-text-color);
             border-radius: 26px;
             width: 100%;
             height:100%;

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Headroom from 'react-headroom';
 import Isvg from 'react-inlinesvg';
 
+import ThemeToggle from './ThemeToggle';
 import arrow from '../static/media/icons/arrow-slim.svg';
 
 class Navbar extends Component {
@@ -68,15 +69,18 @@ class Navbar extends Component {
               <Link href='/about' legacyBehavior><a className="navbar-link">About</a></Link>
               <Link href='/contact' legacyBehavior><a className="navbar-link">Contact</a></Link>
             </div>
-            { this.props.nextProjectLink ?
-              <div>
-                <Link href={this.props.nextProjectLink} legacyBehavior><a className="next navbar-link">{this.props.nextProjectName}<span onClick={this.showModal}><object>  <Isvg className={"next-arrow"} src={arrow} /></object></span>
-                </a></Link>
-              </div>
+            <div className="navbar-controls">
+              <ThemeToggle />
+              { this.props.nextProjectLink ?
+                <div className="next-wrapper">
+                  <Link href={this.props.nextProjectLink} legacyBehavior><a className="next navbar-link">{this.props.nextProjectName}<span onClick={this.showModal}><object>  <Isvg className={"next-arrow"} src={arrow} /></object></span>
+                  </a></Link>
+                </div>
 
-              :
-              null
-            }
+                :
+                null
+              }
+            </div>
           </div>
         </Headroom>
         <style jsx>{`
@@ -85,9 +89,11 @@ class Navbar extends Component {
             top: 0px;
             left: 0px;
             right: 0px;
-            background: #FAFAFA;
+            background: var(--surface-elevated-color);
             z-index: 1 !important;
             transform: translateY(0px);
+            -webkit-box-shadow: var(--navbar-shadow);
+                    box-shadow: var(--navbar-shadow);
           }
           .headroom--unfixed {
             position: absolute !important;
@@ -130,20 +136,28 @@ class Navbar extends Component {
             display: flex;
             -ms-flex-pack: justify;
                 justify-content: space-between;
-            -webkit-box-shadow: 0 .2em .2em 0 rgba(0,0,0,0.10);
-                    box-shadow: 0 .2em .2em 0 rgba(0,0,0,0.10);
-            background: white;
+            -ms-flex-align: center;
+                align-items: center;
+            -ms-flex-wrap: wrap;
+                flex-wrap: wrap;
+            gap: 0.5em;
+            -webkit-box-shadow: var(--navbar-shadow);
+                    box-shadow: var(--navbar-shadow);
+            background: var(--surface-elevated-color);
+            color: var(--link-color);
           }
 
           .links {
             display: flex;
             gap: 1em;
             padding: 1em;
+            -ms-flex-align: center;
+                align-items: center;
           }
 
           .navbar-link {
             display: inline-block;
-            outline: none; 
+            outline: none;
             -webkit-transition: all .2s linear;
             -o-transition: all .2s linear;
             transition: all .2s linear;
@@ -151,13 +165,30 @@ class Navbar extends Component {
             -moz-user-select: none;
             -ms-user-select: none;
             user-select: none;
+            color: inherit;
           }
-          .navbar-link:focus { 
-              outline: none; 
+          .navbar-link:focus {
+              outline: none;
           }
 
           .navbar .next {
             padding: 1em 1em 0em 0em;
+            display: -ms-flexbox;
+            display: flex;
+          }
+
+          .navbar-controls {
+            display: -ms-flexbox;
+            display: flex;
+            -ms-flex-align: center;
+                align-items: center;
+            gap: 1em;
+            padding: 0.5em 1em 0.5em 0;
+            -ms-flex-wrap: wrap;
+                flex-wrap: wrap;
+          }
+
+          .next-wrapper {
             display: -ms-flexbox;
             display: flex;
           }
@@ -232,7 +263,7 @@ class Navbar extends Component {
           }
 
           progress::-webkit-progress-bar {
-            background: #FAFAFA;
+            background: var(--progress-track-color);
           }
 
           progress::-webkit-progress-value {
@@ -277,17 +308,23 @@ class Navbar extends Component {
             background-color: #747a75;
           }
 
-          @media (prefers-color-scheme: dark) {
+          @media only screen and (max-width: 575px) {
             .navbar {
-              background: #222;
+              padding-bottom: 0.2em;
             }
 
-            .navbar-link {
-              color: #eee;
+            .links {
+              padding-bottom: 0;
+              width: 100%;
+              -ms-flex-wrap: wrap;
+                  flex-wrap: wrap;
             }
 
-            progress::-webkit-progress-bar {
-              background: #222;
+            .navbar-controls {
+              padding: 0 1em 0.5em;
+              width: 100%;
+              -ms-flex-pack: start;
+                  justify-content: flex-start;
             }
           }
 

--- a/components/Project.js
+++ b/components/Project.js
@@ -143,7 +143,7 @@ class Project extends Component {
           }
 
           .project-blurb {
-            background-color: white;
+            background-color: var(--surface-elevated-color);
             padding: 1em 1.5em;
             overflow: hidden;
             -webkit-box-shadow: 0 1em 2em 0 rgba(0,0,0,0.30);
@@ -199,7 +199,7 @@ class Project extends Component {
           }
 
           .project-blurb .bg-white, .project-blurb .bg-transition  {
-            background: #FAFAFA;
+            background: var(--surface-elevated-color);
           }
 
           .project-blurb .bg-gradient {

--- a/components/ProjectIcon.js
+++ b/components/ProjectIcon.js
@@ -83,7 +83,7 @@ class ProjectIcon extends Component {
         border: "none",
         margin: "10vh auto",
         visibility: modalVisible,
-        background: "#FAFAFA"
+        background: "var(--surface-elevated-color)"
       }
     }
     
@@ -103,7 +103,7 @@ class ProjectIcon extends Component {
           contentLabel="Modal">
           <div>
             <button onClick={this.hideModal} className={"modal-close-button"}>
-              <img src={close} alt={"close button"} style={{border: 0, height: '1.5em', width: '1.5em', background: '#FAFAFA'}}/>
+              <img src={close} alt={"close button"} style={{border: 0, height: '1.5em', width: '1.5em', background: 'var(--surface-elevated-color)'}}/>
             </button>
             <h2>{this.props.title}</h2>
             <div className="modal-content">
@@ -207,7 +207,7 @@ class ProjectIcon extends Component {
         position: absolute;
         right: 1.5em;
         top: 1.5em;
-        background: #FAFAFA;
+        background: var(--surface-elevated-color);
       }
 
 
@@ -215,7 +215,7 @@ class ProjectIcon extends Component {
         height: 1.5em;
         width: 1.5em;
         border: 0;
-        background: #FAFAFA;
+        background: var(--surface-elevated-color);
       }
 
 

--- a/components/Social.js
+++ b/components/Social.js
@@ -87,7 +87,7 @@ class Social extends Component {
 .social svg {
   width: 20px;
   height: 20px;
-  fill: #1F1E1E;
+  fill: var(--icon-color);
   margin-left: .75em;
 }
 

--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -7,7 +7,9 @@ const applyTheme = (theme) => {
     return;
   }
 
-  document.documentElement.dataset.theme = theme;
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.style.colorScheme = theme;
 };
 
 const ThemeToggle = () => {

--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -1,0 +1,158 @@
+import { useEffect, useRef, useState } from "react";
+
+const STORAGE_KEY = "theme";
+
+const applyTheme = (theme) => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.dataset.theme = theme;
+};
+
+const ThemeToggle = () => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof document !== "undefined") {
+      const currentTheme = document.documentElement?.dataset?.theme;
+
+      if (currentTheme === "light" || currentTheme === "dark") {
+        return currentTheme;
+      }
+    }
+
+    return "light";
+  });
+  const hasStoredPreference = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    let initialTheme = "light";
+
+    if (stored === "light" || stored === "dark") {
+      initialTheme = stored;
+      hasStoredPreference.current = true;
+    } else if (window.matchMedia) {
+      initialTheme = window
+        .matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light";
+    }
+
+    setTheme(initialTheme);
+    applyTheme(initialTheme);
+
+    if (!window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const handleChange = (event) => {
+      if (hasStoredPreference.current) {
+        return;
+      }
+
+      const nextTheme = event.matches ? "dark" : "light";
+      setTheme(nextTheme);
+      applyTheme(nextTheme);
+    };
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+    } else if (typeof mediaQuery.addListener === "function") {
+      mediaQuery.addListener(handleChange);
+    }
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", handleChange);
+      } else if (typeof mediaQuery.removeListener === "function") {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  const toggleTheme = () => {
+    const nextTheme = theme === "dark" ? "light" : "dark";
+
+    hasStoredPreference.current = true;
+    setTheme(nextTheme);
+    applyTheme(nextTheme);
+
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, nextTheme);
+    }
+  };
+
+  const label = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+  const icon = theme === "dark" ? "🌙" : "☀️";
+  const text = theme === "dark" ? "Dark" : "Light";
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={toggleTheme}
+      aria-label={label}
+    >
+      <span aria-hidden="true" className="theme-toggle__icon">
+        {icon}
+      </span>
+      <span className="theme-toggle__text">{text}</span>
+      <style jsx>{`
+        .theme-toggle {
+          align-items: center;
+          background: transparent;
+          border: 1px solid var(--border-color);
+          border-radius: 999px;
+          color: inherit;
+          cursor: pointer;
+          display: inline-flex;
+          font: inherit;
+          gap: 0.4em;
+          padding: 0.35em 0.9em;
+          transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+          white-space: nowrap;
+        }
+
+        .theme-toggle:hover,
+        .theme-toggle:focus-visible {
+          background: var(--surface-hover-color);
+          border-color: var(--focus-outline);
+        }
+
+        .theme-toggle:focus-visible {
+          outline: 2px solid var(--focus-outline);
+          outline-offset: 2px;
+        }
+
+        .theme-toggle__icon {
+          font-size: 1rem;
+          line-height: 1;
+        }
+
+        .theme-toggle__text {
+          font-size: 0.95rem;
+        }
+
+        @media only screen and (max-width: 575px) {
+          .theme-toggle__text {
+            display: none;
+          }
+
+          .theme-toggle {
+            padding: 0.35em 0.65em;
+          }
+        }
+      `}</style>
+    </button>
+  );
+};
+
+export default ThemeToggle;
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postbuild": "node scripts/create-nojekyll.js",
     "start": "next start",
     "clearCache": "rimraf node_modules/.cache",
-    "publish": "git add out/ && git commit -m \"Deploy Next.js to harritaito.github.io\" && git subtree push --prefix out origin gh-pages",
+    "publish": "git add out/ && (git diff --cached --quiet && echo \"No changes to commit; deploying existing build.\" || git commit -m \"Deploy Next.js to harritaito.github.io\") && git subtree push --prefix out origin gh-pages",
     "deploy": "npm run build && npm run publish",
     "test": "jest"
   },

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,19 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import Fonts from "../components/Fonts";
 
+const SITE_METADATA = Object.freeze({
+  title: "Harri Halonen",
+  description:
+    "The website of Harri Halonen (@harritaito), a Finnish experience designer living and working in Tampere, Finland.",
+  siteUrl: "https://harritaito.com/",
+  locale: "en_US",
+  twitterHandle: "@harritaito",
+  socialImage: {
+    url: "https://harritaito.com/static/media/twittericon.png",
+    alt: "Harri Halonen logomark",
+  },
+});
+
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx);
@@ -25,16 +38,26 @@ export default class MyDocument extends Document {
         doc.style.colorScheme = theme;
       }
     )();`;
+    const { title, description, siteUrl, locale, twitterHandle, socialImage } =
+      SITE_METADATA;
 
     return (
       <Html lang="en">
         <Head>
           <meta charSet="UTF-8" />
-          <meta httpEquiv="Cache-Control: max-age=86400" content="public" />
+          <meta
+            httpEquiv="Cache-Control"
+            content="public, max-age=86400"
+          />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, viewport-fit=cover"
+          />
           <meta
             name="description"
-            content="The website of Harri Halonen (@harritaito), a Finnish experience designer living and working in Tampere, Finland."
+            content={description}
           />
+          <link rel="canonical" href={siteUrl} />
           <link rel="icon" sizes="192x192" href="/static/media/touch-icon.png" />
           <link rel="apple-touch-icon" href="/static/media/touch-icon.png" />
           <link
@@ -43,24 +66,30 @@ export default class MyDocument extends Document {
             color="#49B882"
           />
           <link rel="icon" href="/static/favicon.ico" />
-          <meta property="og:url" content="https://harritaito.com/" />
-          <meta property="og:title" content="Harri Halonen" />
+          <meta property="og:url" content={siteUrl} />
+          <meta property="og:type" content="website" />
+          <meta property="og:title" content={title} />
+          <meta property="og:site_name" content={title} />
           <meta
             property="og:description"
-            content="The website of Harri Halonen (@harritaito), a Finnish experience designer living and working in Tampere, Finland."
+            content={description}
           />
-          <meta name="twitter:site" content="https://harritaito.com/" />
+          <meta property="og:locale" content={locale} />
+          <meta name="twitter:site" content={twitterHandle} />
+          <meta name="twitter:creator" content={twitterHandle} />
+          <meta name="twitter:title" content={title} />
+          <meta name="twitter:description" content={description} />
           <meta name="twitter:card" content="summary_large_image" />
           <meta
             name="twitter:image"
-            content="https://harritaito.com/static/media/twittericon.png"
+            content={socialImage.url}
           />
+          <meta name="twitter:image:alt" content={socialImage.alt} />
           <meta
             property="og:image"
-            content="https://harritaito.com/static/media/twittericon.png"
+            content={socialImage.url}
           />
-          <meta property="og:image:width" content="1200" />
-          <meta property="og:image:height" content="630" />
+          <meta property="og:image:alt" content={socialImage.alt} />
           <meta name="color-scheme" content="light dark" />
           <script dangerouslySetInnerHTML={{ __html: setInitialTheme }} />
           <style>{`

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -8,6 +8,25 @@ export default class MyDocument extends Document {
   }
 
   render() {
+    const setInitialTheme = `(
+      function() {
+        try {
+          var storageKey = 'theme';
+          var doc = document.documentElement;
+          var stored = localStorage.getItem(storageKey);
+          if (stored === 'light' || stored === 'dark') {
+            doc.dataset.theme = stored;
+          } else if (window.matchMedia) {
+            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            doc.dataset.theme = prefersDark ? 'dark' : 'light';
+          } else {
+            doc.dataset.theme = 'light';
+          }
+        } catch (e) {
+        }
+      }
+    )();`;
+
     return (
       <Html lang="en">
         <Head>
@@ -44,7 +63,42 @@ export default class MyDocument extends Document {
           <meta property="og:image:width" content="1200" />
           <meta property="og:image:height" content="630" />
           <meta name="color-scheme" content="light dark" />
+          <script dangerouslySetInnerHTML={{ __html: setInitialTheme }} />
           <style>{`
+                :root {
+                color-scheme: light dark;
+                --background-color: #fafafa;
+                --surface-color: #f5f5f5;
+                --surface-elevated-color: #ffffff;
+                --text-color: #111827;
+                --muted-text-color: #4b5563;
+                --link-color: #0f172a;
+                --link-hover-color: #49b882;
+                --border-color: rgba(15, 23, 42, 0.12);
+                --navbar-shadow: 0 .2em .2em 0 rgba(0,0,0,0.10);
+                --progress-track-color: #e5e7eb;
+                --icon-color: #1f1e1e;
+                --focus-outline: #49b882;
+                --surface-hover-color: rgba(15, 23, 42, 0.05);
+                }
+
+                :root[data-theme='dark'] {
+                color-scheme: dark;
+                --background-color: #0b1120;
+                --surface-color: #111827;
+                --surface-elevated-color: #1f2937;
+                --text-color: #e2e8f0;
+                --muted-text-color: #94a3b8;
+                --link-color: #e2e8f0;
+                --link-hover-color: #7ce3b2;
+                --border-color: rgba(148, 163, 184, 0.4);
+                --navbar-shadow: 0 .2em .8em 0 rgba(8, 15, 32, 0.8);
+                --progress-track-color: #1f2937;
+                --icon-color: #e2e8f0;
+                --focus-outline: #7ce3b2;
+                --surface-hover-color: rgba(148, 163, 184, 0.18);
+                }
+
                 body {
                 margin: 0;
                 padding: 0;
@@ -53,7 +107,9 @@ export default class MyDocument extends Document {
                 text-rendering: optimizeLegibility;
                 -webkit-font-smoothing: antialiased;
                 position: relative;
-                background: #fafafa;
+                background: var(--background-color);
+                color: var(--text-color);
+                transition: background-color 0.3s ease, color 0.3s ease;
                 }
 
                 #root {
@@ -129,18 +185,28 @@ export default class MyDocument extends Document {
                 a {
                 text-decoration: none;
                 display: inline-block;
-                color: #000;
+                color: var(--link-color);
                 overflow: visible;
                 cursor: pointer;
                 outline: none;
+                transition: color 0.2s ease;
+                }
+
+                a:hover {
+                color: var(--link-hover-color);
                 }
 
                 a:focus {
                 outline: none;
                 }
 
+                a:focus-visible {
+                outline: 2px solid var(--focus-outline);
+                outline-offset: 2px;
+                }
+
                 p a:visited {
-                color: #000;
+                color: var(--link-color);
                 text-decoration: none;
                 }
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -10,20 +10,19 @@ export default class MyDocument extends Document {
   render() {
     const setInitialTheme = `(
       function() {
+        var doc = document.documentElement;
+        var theme = 'light';
         try {
           var storageKey = 'theme';
-          var doc = document.documentElement;
           var stored = localStorage.getItem(storageKey);
           if (stored === 'light' || stored === 'dark') {
-            doc.dataset.theme = stored;
-          } else if (window.matchMedia) {
-            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            doc.dataset.theme = prefersDark ? 'dark' : 'light';
-          } else {
-            doc.dataset.theme = 'light';
+            theme = stored;
+          } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            theme = 'dark';
           }
-        } catch (e) {
-        }
+        } catch (e) {}
+        doc.dataset.theme = theme;
+        doc.style.colorScheme = theme;
       }
     )();`;
 
@@ -1444,18 +1443,7 @@ export default class MyDocument extends Document {
                 }
                 }
 
-                @media (prefers-color-scheme: dark) {
-                body {
-                    background: #121212;
-                    color: #eee;
-                }
-
-                a, p a:visited {
-                    color: #eee;
-                }
-                }
-
-            `}</style>
+                `}</style>
         </Head>
         <body>
           {this.props.customValue}


### PR DESCRIPTION
## Summary
- add a persistent theme toggle component that respects system preferences
- expose light and dark palettes through CSS variables and update the navigation to use them
- align button, project, icon, and social components with the new theming tokens

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690145daee10833086b999486ce0fe06