### PR TITLE
fix: allow publish script to skip empty commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postbuild": "node scripts/create-nojekyll.js",
     "start": "next start",
     "clearCache": "rimraf node_modules/.cache",
-    "publish": "git add out/ && git commit -m \"Deploy Next.js to harritaito.github.io\" && git subtree push --prefix out origin gh-pages",
+    "publish": "git add out/ && (git diff --cached --quiet && echo \"No changes to commit; deploying existing build.\" || git commit -m \"Deploy Next.js to harritaito.github.io\") && git subtree push --prefix out origin gh-pages",
     "deploy": "npm run build && npm run publish",
     "test": "jest"
   },


### PR DESCRIPTION
## Summary
- avoid failing deployments by checking for staged changes before committing in the publish script

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690148455b8c833098060732088d82d1