### PR TITLE
fix: improve mobile case study spacing

### DIFF
--- a/components/Project.js
+++ b/components/Project.js
@@ -345,6 +345,26 @@ class Project extends Component {
               margin-top: 100px;
             }
           }
+
+          @media only screen and (max-width: 45rem) {
+            .project-blurb {
+              margin-top: 1.5em;
+              -webkit-box-shadow: 0 0.75em 1.5em 0 rgba(0,0,0,0.22);
+                      box-shadow: 0 0.75em 1.5em 0 rgba(0,0,0,0.22);
+            }
+
+            .project-image {
+              border-radius: 0.75rem;
+            }
+
+            .plx {
+              margin-top: 1.5em;
+              opacity: 1 !important;
+              -webkit-transform: none !important;
+                  -ms-transform: none !important;
+                      transform: none !important;
+            }
+          }
         `}</style>
       </div>
     );


### PR DESCRIPTION
## Summary
- adjust case study project cards on small screens to sit below images with softer shadows and rounded corners
- disable parallax translation on mobile to prevent text overlapping case study images and keep content readable

## Testing
- npm test
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445f68481c8330839c72c3aaa7e103)