### PR TITLE
fix: safe-area layout, refactor case-study cards, normalize social icons

### DIFF
--- a/components/Project.js
+++ b/components/Project.js
@@ -33,18 +33,23 @@ class Project extends Component {
   renderProjectLink() {
     return (
       <Link href={this.props.link} className="project-link-container">
-        <div className={"project-blurb " + this.props.color}>
-          <h2>{this.props.title}</h2>
-          <div style={{marginTop: "1.5em"}}>{this.props.description}</div>
-          <div className="bottom">
-            <div className={"next navbar-link " + this.props.color}>
-              <span className="case-study-text">Case Study</span>
-              <span className="next-arrow" aria-hidden="true">
-                <Isvg className="next-arrow-icon" src={arrow} />
-              </span>
+        <article className={`case-card ${this.props.color}`}>
+          <div className="case-card__media">
+            <img className="case-card__image" src={this.props.image} alt={this.props.alt} />
+          </div>
+          <div className="case-card__content">
+            <h3 className="case-card__title">{this.props.title}</h3>
+            <p className="case-card__description">{this.props.description}</p>
+            <div className="bottom">
+              <div className={"next navbar-link " + this.props.color}>
+                <span className="case-study-text">Case Study</span>
+                <span className="next-arrow" aria-hidden="true">
+                  <Isvg className="next-arrow-icon" src={arrow} />
+                </span>
+              </div>
             </div>
           </div>
-        </div>
+        </article>
       </Link>
     );
   }
@@ -54,41 +59,36 @@ class Project extends Component {
     return (
       <div className={this.props.title + " Project"}>
         <div className="row">
-          <div className="col-xs-12 col-sm-10 col-md-10 col-lg-offset-0 col-lg-8 col-xl-offset-1 col-xl-7">
-            <img className="project-image" src={this.props.image} alt={this.props.alt}/>
-          </div>
-        </div>
-        <div className="row">
-          <div className="col-xs-12 col-sm-offset-2 col-sm-10 col-md-offset-4 col-md-8 col-lg-offset-6 col-lg-6 col-xl-5">
-            {this.props.parallax ?
+          <div className="col-xs-12 col-sm-10 col-sm-offset-1 col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2 col-xl-7 col-xl-offset-2">
+            {this.props.parallax ? (
               <Plx
                 className="plx"
                 animateWhenNotInViewport={true}
                 parallaxData={[
                   {
                     start: this.props.percentage,
-                    duration: this.props.parallax ? '9%' : "0%",
+                    duration: this.props.parallax ? "9%" : "0%",
                     properties: [
                       {
                         startValue: 0,
                         endValue: this.props.endValue,
-                        property: 'translateY',
-                        unit: "px"
+                        property: "translateY",
+                        unit: "px",
                       },
                       {
                         startValue: 0,
                         endValue: 1,
-                        property: 'opacity',
-                      }
-                    ]
-                  }
+                        property: "opacity",
+                      },
+                    ],
+                  },
                 ]}
               >
-              {this.renderProjectLink()}
-              </Plx> :
-
+                {this.renderProjectLink()}
+              </Plx>
+            ) : (
               this.renderProjectLink()
-            }
+            )}
           </div>
         </div>
         <style jsx>{`
@@ -110,74 +110,59 @@ class Project extends Component {
             outline: none;
           }
 
-          .Project:hover .project-image {
-            -webkit-box-shadow: 0 0.75em 1.25em 0 rgba(0,0,0,0.30);
-                    box-shadow: 0 0.75em 1.25em 0 rgba(0,0,0,0.30);
-          }
-
-          .Project:hover .project-blurb {
-            -webkit-box-shadow: 0 1.5em 2.5em 0 rgba(0,0,0,0.30);
-                    box-shadow: 0 1.5em 2.5em 0 rgba(0,0,0,0.30);
-          }
-
-
-          .project-image {
-            display: block;
-            -o-object-fit: cover;
-              object-fit: cover;
-            max-width: 100%;
-            height: auto;
-            padding: 0;
-            overflow: hidden;
-            -webkit-box-shadow: 0 0.5em 1em 0 rgba(0,0,0,0.30);
-                    box-shadow: 0 0.5em 1em 0 rgba(0,0,0,0.30);
-            -webkit-transition: -webkit-box-shadow .5s ease;
-            transition: -webkit-box-shadow .5s ease;
-            -o-transition: box-shadow .5s ease;
-            transition: box-shadow .5s ease;
-            transition: box-shadow .5s ease, -webkit-box-shadow .5s ease;
-          }
-
           .plx {
             opacity: 0;
           }
 
-          .project-blurb {
-            background-color: var(--surface-elevated-color);
-            padding: 1em 1.5em;
+          .case-card {
+            border-radius: 1.5rem;
             overflow: hidden;
+            background-color: var(--surface-elevated-color);
             -webkit-box-shadow: 0 1em 2em 0 rgba(0,0,0,0.30);
                     box-shadow: 0 1em 2em 0 rgba(0,0,0,0.30);
-            height: auto;
-            margin-top: -10em;
-            -webkit-transition: all .6s ease;
-            -o-transition: all .6s ease;
-            transition: all .6s ease;
-            position: relative;
+            -webkit-transition: box-shadow .5s ease;
+            transition: box-shadow .5s ease;
+            display: flex;
+            flex-direction: column;
           }
 
-          .project-blurb .next-arrow{
+          .project-link-container:hover .case-card {
+            -webkit-box-shadow: 0 1.5em 2.5em 0 rgba(0,0,0,0.30);
+                    box-shadow: 0 1.5em 2.5em 0 rgba(0,0,0,0.30);
+          }
+
+          .case-card__media {
+            position: relative;
+            aspect-ratio: 16 / 9;
+            overflow: hidden;
+          }
+
+          .case-card__image {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+          }
+
+          .case-card__content {
+            padding: 1.5em;
+          }
+
+          .case-card__title {
+            margin: 0 0 0.5em;
+            font-size: clamp(1.125rem, 4vw, 1.75rem);
+            line-height: 1.2;
+          }
+
+          .case-card__description {
+            margin: 0 0 1.25em;
+            line-height: 1.7;
+          }
+
+          .case-card .next-arrow {
             margin-left: 1rem;
             height: 200px;
             weight: 200px;
-          }
-
-          .project-blurb.green:hover {
-            background-color: #0BAB28;
-          }
-
-
-          .project-blurb.blue:hover {
-            background-color: #1e95ed;
-          }
-
-
-          .project-blurb.red:hover {
-            background-color: #fa5858;
-          }
-
-          .project-blurb.purple:hover {
-            background-color: #9157ff;
           }
 
           /* Gradient background code */
@@ -228,19 +213,7 @@ class Project extends Component {
 
           /* Hover Styling */
 
-          .project-blurb:hover {
-            color: #FAFAFA;
-          }
-
-          .Project .project-blurb:hover .case-study-text {
-            color: #FAFAFA;
-          }
-
-          .Project .project-blurb:hover .next-arrow-icon {
-            fill: #FAFAFA;
-          }
-
-          .project-blurb:hover .next-arrow{
+          .case-card:hover .next-arrow {
             -webkit-transform: translateX(5px);
                 -ms-transform: translateX(5px);
                     transform: translateX(5px);
@@ -284,35 +257,35 @@ class Project extends Component {
             transition: all .6s ease;
           }
 
-          .project-blurb .next.green .case-study-text {
+          .case-card .next.green .case-study-text {
             color: #12a42d;
           }
 
-          .project-blurb .green .next-arrow-icon {
+          .case-card .green .next-arrow-icon {
             fill: #12a42d;
           }
 
-          .project-blurb .next.blue .case-study-text {
+          .case-card .next.blue .case-study-text {
             color: #1e95ed;
           }
 
-          .project-blurb .blue .next-arrow-icon {
+          .case-card .blue .next-arrow-icon {
             fill: #1e95ed;
           }
 
-          .project-blurb .next.red .case-study-text {
+          .case-card .next.red .case-study-text {
             color: #fa5858;
           }
 
-          .project-blurb .red .next-arrow-icon {
+          .case-card .red .next-arrow-icon {
             fill: #fa5858;
           }
 
-          .project-blurb .purple .case-study-text {
+          .case-card .purple .case-study-text {
             color: #9157ff;
           }
 
-          .project-blurb .purple .next-arrow-icon {
+          .case-card .purple .next-arrow-icon {
             fill: #9157ff;
           }
 
@@ -325,40 +298,13 @@ class Project extends Component {
           }
 
 
-          @media only screen and (max-width: 575px) {
-            .plx {
-              margin-top: 35vh;
-
-            }
-          }
-
-
-          @media only screen and (max-width: 767px) and (min-width: 576px) {
-            .plx {
-              margin-top: 150px;
-            }
-          }
-
-
-          @media only screen and (max-width: 992px) and (min-width: 768px) {
-            .plx {
-              margin-top: 100px;
-            }
-          }
-
           @media only screen and (max-width: 45rem) {
-            .project-blurb {
-              margin-top: 1.5em;
+            .case-card {
               -webkit-box-shadow: 0 0.75em 1.5em 0 rgba(0,0,0,0.22);
                       box-shadow: 0 0.75em 1.5em 0 rgba(0,0,0,0.22);
             }
 
-            .project-image {
-              border-radius: 0.75rem;
-            }
-
             .plx {
-              margin-top: 1.5em;
               opacity: 1 !important;
               -webkit-transform: none !important;
                   -ms-transform: none !important;

--- a/components/Social.js
+++ b/components/Social.js
@@ -74,10 +74,20 @@ class Social extends Component {
         <style jsx>{`
       .social {
   text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .social a {
   text-decoration: none;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
 }
 
 .social a::after{
@@ -88,7 +98,6 @@ class Social extends Component {
   width: 20px;
   height: 20px;
   fill: var(--icon-color);
-  margin-left: .75em;
 }
 
 .social path, footer .social rect {
@@ -138,6 +147,7 @@ class Social extends Component {
 @media only screen and (max-width: 575px)  {
   .social {
     text-align: center;
+    justify-content: center;
   }
 }
 

--- a/pages/Home.js
+++ b/pages/Home.js
@@ -267,6 +267,12 @@ class Home extends Component {
             margin-top: 1.5em;
           }
 
+          .Home .intro {
+            min-height: 100svh;
+            min-height: 100dvh;
+            padding-bottom: calc(2.5rem + var(--sab));
+          }
+
           .Home .tagline {
             font-size: 1.6em;
             font-weight: 600;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -126,11 +126,19 @@ export default class MyDocument extends Document {
                 --icon-color: #e2e8f0;
                 --focus-outline: #7ce3b2;
                 --surface-hover-color: rgba(148, 163, 184, 0.18);
+                --sat: env(safe-area-inset-top);
+                --sab: env(safe-area-inset-bottom);
+                }
+
+                html {
+                scroll-padding-top: calc(var(--header-h, 0px) + var(--sat));
                 }
 
                 body {
                 margin: 0;
                 padding: 0;
+                padding-top: var(--sat);
+                padding-bottom: var(--sab);
                 font-family: Rubik, sans-serif;
                 font-size: 16px;
                 text-rendering: optimizeLegibility;


### PR DESCRIPTION
### Motivation
- Prevent content from being obscured by iOS Safari UI (dynamic address bar / safe-area) for fullscreen hero sections and general page layout.
- Fix case-study card layout where titles/overlays could overlap media and body copy; provide a clearer media + content structure.
- Improve mobile tap targets and visual consistency for footer social icons.

### Description
- Added safe-area CSS variables and adjustments in `pages/_document.js`: introduced `--sat` and `--sab` (via `env(safe-area-inset-*)`), set `html { scroll-padding-top: calc(var(--header-h, 0px) + var(--sat)); }` and applied `padding-top` / `padding-bottom` to `body` to respect device safe-areas.
- Made hero/intro stable-viewport aware in `pages/Home.js`: added `min-height: 100svh; min-height: 100dvh;` and `padding-bottom: calc(2.5rem + var(--sab))` to avoid toolbar overlap.
- Rebuilt the project/case study card component in `components/Project.js`: replaced the old `.project-blurb` block with a `article.case-card` layout that separates media (`.case-card__media`) and content (`.case-card__content`), uses an `img` with `object-fit: cover`, applies unified border-radius/overflow handling, and uses `clamp()` for responsive card title sizing.
- Kept parallax behaviour but reorganized the markup/column classes so cards render consistently across breakpoints.
- Standardized social icons in `components/Social.js`: wrapped each anchor in a 44×44 inline-flex button, made the icon area circular (consistent tap target), and switched footer social layout to a small flex grid for consistent spacing.

### Testing
- Ran unit/test suite: `npm test` — Jest results: 5 test suites passed, 13 tests passed (all green).
- Built production output: `npm run build` — Next build completed successfully and static pages were generated.
- Both automated checks (`npm test` and `npm run build`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ee879e248330a0e9db1dba03043e)