### PR TITLE
Add project-local agent config and team guide

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,9 @@
+# ~/.codex/AGENTS.md (project-local profile)
+
+## Working agreements
+
+- Run `npm test` and `npm run build` after code or documentation changes.
+- Prefer small, reviewable commits that follow Conventional Commits.
+- Keep `package-lock.json` unchanged unless a task explicitly requires dependency updates.
+- For docs updates, keep ATX headings and wrap lines to 100 characters.
+- Summarize which instruction files were applied when a task starts.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+project_doc_fallback_filenames = ["TEAM_GUIDE.md", ".agents.md"]
+project_doc_max_bytes = 65536

--- a/TEAM_GUIDE.md
+++ b/TEAM_GUIDE.md
@@ -1,0 +1,7 @@
+# Team Guide
+
+## Repository defaults
+
+- Run `npm test` before opening a pull request.
+- Run `npm run build` before opening a pull request.
+- Keep changes scoped to the request and avoid unrelated refactors.


### PR DESCRIPTION
### Motivation

- Provide a project-local agent profile and repository conventions to standardize developer and automation behavior.
- Surface lightweight documentation for contributors about test/build expectations and commit style.

### Description

- Add `.codex/AGENTS.md` containing working agreements such as running `npm test` and `npm run build`, keeping `package-lock.json` unchanged, and doc formatting rules.
- Add `.codex/config.toml` with project doc lookup settings (`project_doc_fallback_filenames` and `project_doc_max_bytes`).
- Add `TEAM_GUIDE.md` with repository defaults including running `npm test` and `npm run build` before opening a pull request.

### Testing

- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6f259b188330976e7cd4ff8f77e7)