### PR TITLE
Use :global for scoped styles, fix width typo, and add Project tests

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -59,7 +59,7 @@ class Button extends Component {
         <style jsx>{`
           /* Solid Button Rules */
 
-          .button .button-link {
+          .button :global(.button-link) {
             display: inline-block;
             position: relative;
             border-radius: 26px;
@@ -71,11 +71,11 @@ class Button extends Component {
             transition: all .6s linear;
             font-weight: 500;
           }
-          .button .button-link--static {
+          .button :global(.button-link--static) {
             cursor: default;
           }
           @media only screen and (max-width: 45rem) {
-          .button .button-link {font-size: 0.9rem;}
+          .button :global(.button-link) {font-size: 0.9rem;}
         }
 
           .button:hover {
@@ -85,18 +85,18 @@ class Button extends Component {
 
           /* Outline Button Rules */
 
-          .button.outline .button-link {
+          .button.outline :global(.button-link) {
             color: var(--muted-text-color);
             padding: 0;
           }
 
-          .button.outline .button-link span {
+          .button.outline :global(.button-link span) {
             position: relative;
             display: inline-block;
             padding: .3em 1.3em;
           }
 
-          .button.outline .button-link::before {
+          .button.outline :global(.button-link::before) {
             border: 2px solid var(--muted-text-color);
             border-radius: 26px;
             width: 100%;
@@ -109,37 +109,37 @@ class Button extends Component {
 
           /* Outline Button Colors */
 
-          .button.outline.blue .button-link:hover span {
+          .button.outline.blue :global(.button-link:hover span) {
             color: #1e95ed
           }
 
-          .button.outline.blue .button-link:hover::before {
+          .button.outline.blue :global(.button-link:hover::before) {
             border-color: #1e95ed;
           }
 
 
-          .button.outline.green .button-link:hover span {
+          .button.outline.green :global(.button-link:hover span) {
             color: #12a42d
           }
 
-          .button.outline.green .button-link:hover::before {
+          .button.outline.green :global(.button-link:hover::before) {
             border-color: #12a42d;
           }
 
-          .button.outline.red .button-link:hover span {
+          .button.outline.red :global(.button-link:hover span) {
             color: #fa5858;
           }
 
-          .button.outline.red .button-link:hover::before {
+          .button.outline.red :global(.button-link:hover::before) {
             border-color: #fa5858;
           }
 
 
-          .button.outline.purple .button-link:hover span {
+          .button.outline.purple :global(.button-link:hover span) {
             color: #9157ff;
           }
 
-          .button.outline.purple .button-link:hover::before {
+          .button.outline.purple :global(.button-link:hover::before) {
             border-color: #9157ff;
           }
         `}</style>

--- a/components/Project.js
+++ b/components/Project.js
@@ -100,21 +100,21 @@ class Project extends Component {
             .Project {margin-top: 5em; margin-bottom: 5em;}
           }
 
-          .project-link-container {
+          .Project :global(.project-link-container) {
             color: inherit;
             display: block;
             text-decoration: none;
           }
 
-          .project-link-container:focus {
+          .Project :global(.project-link-container:focus) {
             outline: none;
           }
 
-          .plx {
+          .Project :global(.plx) {
             opacity: 0;
           }
 
-          .case-card {
+          .Project :global(.case-card) {
             border-radius: 1.5rem;
             overflow: hidden;
             background-color: var(--surface-elevated-color);
@@ -126,43 +126,43 @@ class Project extends Component {
             flex-direction: column;
           }
 
-          .project-link-container:hover .case-card {
+          .Project :global(.project-link-container:hover .case-card) {
             -webkit-box-shadow: 0 1.5em 2.5em 0 rgba(0,0,0,0.30);
                     box-shadow: 0 1.5em 2.5em 0 rgba(0,0,0,0.30);
           }
 
-          .case-card__media {
+          .Project :global(.case-card__media) {
             position: relative;
             aspect-ratio: 16 / 9;
             overflow: hidden;
           }
 
-          .case-card__image {
+          .Project :global(.case-card__image) {
             width: 100%;
             height: 100%;
             object-fit: cover;
             display: block;
           }
 
-          .case-card__content {
+          .Project :global(.case-card__content) {
             padding: 1.5em;
           }
 
-          .case-card__title {
+          .Project :global(.case-card__title) {
             margin: 0 0 0.5em;
             font-size: clamp(1.125rem, 4vw, 1.75rem);
             line-height: 1.2;
           }
 
-          .case-card__description {
+          .Project :global(.case-card__description) {
             margin: 0 0 1.25em;
             line-height: 1.7;
           }
 
-          .case-card .next-arrow {
+          .Project :global(.case-card .next-arrow) {
             margin-left: 1rem;
             height: 200px;
-            weight: 200px;
+            width: 200px;
           }
 
           /* Gradient background code */
@@ -213,7 +213,7 @@ class Project extends Component {
 
           /* Hover Styling */
 
-          .case-card:hover .next-arrow {
+          .Project :global(.case-card:hover .next-arrow) {
             -webkit-transform: translateX(5px);
                 -ms-transform: translateX(5px);
                     transform: translateX(5px);
@@ -221,27 +221,27 @@ class Project extends Component {
 
           /* Link Styling */
 
-          .bottom {
+          .Project :global(.bottom) {
             display: -ms-flexbox;
             display: flex;
             -ms-flex-pack: justify;
                 justify-content: space-between
           }
 
-          .bottom .next {
+          .Project :global(.bottom .next) {
             display: -ms-flexbox;
             display: flex;
             padding: .5em 0 1em;
           }
 
-          .case-study-text {
+          .Project :global(.case-study-text) {
             display: inline-block;
             -webkit-transition: all .6s ease;
             -o-transition: all .6s ease;
             transition: all .6s ease;
           }
 
-          .bottom .next-arrow {
+          .Project :global(.bottom .next-arrow) {
             width: 1em;
             height: 1em;
             margin-left: 4px;
@@ -251,45 +251,45 @@ class Project extends Component {
             display: block;
           }
 
-          .bottom .next-arrow-icon {
+          .Project :global(.bottom .next-arrow-icon) {
             -webkit-transition: all .6s ease;
             -o-transition: all .6s ease;
             transition: all .6s ease;
           }
 
-          .case-card .next.green .case-study-text {
+          .Project :global(.case-card .next.green .case-study-text) {
             color: #12a42d;
           }
 
-          .case-card .green .next-arrow-icon {
+          .Project :global(.case-card .green .next-arrow-icon) {
             fill: #12a42d;
           }
 
-          .case-card .next.blue .case-study-text {
+          .Project :global(.case-card .next.blue .case-study-text) {
             color: #1e95ed;
           }
 
-          .case-card .blue .next-arrow-icon {
+          .Project :global(.case-card .blue .next-arrow-icon) {
             fill: #1e95ed;
           }
 
-          .case-card .next.red .case-study-text {
+          .Project :global(.case-card .next.red .case-study-text) {
             color: #fa5858;
           }
 
-          .case-card .red .next-arrow-icon {
+          .Project :global(.case-card .red .next-arrow-icon) {
             fill: #fa5858;
           }
 
-          .case-card .purple .case-study-text {
+          .Project :global(.case-card .purple .case-study-text) {
             color: #9157ff;
           }
 
-          .case-card .purple .next-arrow-icon {
+          .Project :global(.case-card .purple .next-arrow-icon) {
             fill: #9157ff;
           }
 
-          .project-link-container{
+          .Project :global(.project-link-container) {
             cursor: pointer;
             -webkit-user-select: none;
             -moz-user-select: none;
@@ -299,12 +299,12 @@ class Project extends Component {
 
 
           @media only screen and (max-width: 45rem) {
-            .case-card {
+            .Project :global(.case-card) {
               -webkit-box-shadow: 0 0.75em 1.5em 0 rgba(0,0,0,0.22);
                       box-shadow: 0 0.75em 1.5em 0 rgba(0,0,0,0.22);
             }
 
-            .plx {
+            .Project :global(.plx) {
               opacity: 1 !important;
               -webkit-transform: none !important;
                   -ms-transform: none !important;

--- a/components/__tests__/Button.test.js
+++ b/components/__tests__/Button.test.js
@@ -3,15 +3,6 @@ import { renderToStaticMarkup } from 'react-dom/server';
 
 import Button from '../Button';
 
-// Mock next/link to avoid Next.js internals in unit tests
-jest.mock('next/link', () => {
-  const React = require('react');
-  return {
-    __esModule: true,
-    default: ({ href, children, ...props }) => React.createElement('a', { href, ...props }, children)
-  };
-});
-
 describe('Button.isLinkInternal', () => {
   test('returns true for relative links', () => {
     const btn = new Button({ label: 'Test', link: '/about', color: 'green' });
@@ -48,7 +39,7 @@ describe('Button rendering', () => {
   test('renders an anchor for internal links', () => {
     const markup = renderToStaticMarkup(<Button label="Test" link="/about" color="green" />);
     expect(markup).toContain('href="/about"');
-    expect(markup).toContain('class="button-link"');
+    expect(markup).toMatch(/class="[^"]*button-link/);
   });
 
   test('renders a span when no link is provided', () => {

--- a/components/__tests__/Project.test.js
+++ b/components/__tests__/Project.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import Project from '../Project';
+
+jest.mock('react-plx', () => {
+  const React = require('react');
+  return ({ children }) => React.createElement('div', null, children);
+});
+
+jest.mock('react-inlinesvg', () => {
+  const React = require('react');
+  return ({ className }) => React.createElement('svg', { className });
+});
+
+describe('Project rendering', () => {
+  test('renders link and card classes used by scoped styles', () => {
+    const markup = renderToStaticMarkup(
+      <Project
+        title="Test Project"
+        description="A test case study"
+        image="/static/test.jpg"
+        link="/test-project"
+        alt="Test project image"
+        color="blue"
+        parallax={true}
+      />
+    );
+
+    expect(markup).toContain('href="/test-project"');
+    expect(markup).toMatch(/class="[^"]*project-link-container/);
+    expect(markup).toMatch(/class="[^"]*case-card[^"]*blue/);
+  });
+});

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -15,7 +15,7 @@ class PageNotFound extends Component {
         }/>
         <Row content={
           <div style={{marginTop: "1.5em"}} className="col-xs-12 col-sm-12 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6 col-xl-6">
-           Feel free to chill out, or <Link href='/'>head back to the home page.<div style={{display: 'block', height: 8, width: '98%', background: 'rgba(139, 200, 246, 0.565)', marginTop: -9, marginLeft: 2}} /></Link>
+           Feel free to chill out, or <Link href='/' className="home-link">head back to the home page.<span className="home-link__underline" aria-hidden="true" /></Link>
           </div>
         }/>
         <style jsx>{`
@@ -41,6 +41,19 @@ class PageNotFound extends Component {
           background-size: cover;
           z-index: -1;
           opacity: .55;
+        }
+
+        :global(.home-link) {
+          display: inline-block;
+        }
+
+        :global(.home-link__underline) {
+          display: block;
+          height: 8px;
+          width: 98%;
+          background: rgba(139, 200, 246, 0.565);
+          margin-top: -9px;
+          margin-left: 2px;
         }
 
         .pohja svg {


### PR DESCRIPTION
### Motivation

- Ensure styled-jsx selectors target global child classes so scoped styles apply correctly to inner components and avoid style leakage.
- Add unit coverage for the `Project` component and update `Button` tests to be resilient to class-name scoping. 
- Fix a CSS typo where `weight` was used instead of `width` for arrow sizing.

### Description

- Replace descendant selectors like `.button .button-link` and `.case-card .next-arrow` with scoped selectors that use `:global(...)`, e.g. `.button :global(.button-link)`, so styled-jsx correctly targets global class names inside the component.  
- Correct a typo in `Project.js` changing `weight: 200px;` to `width: 200px;` for `.case-card .next-arrow`.  
- Remove the `next/link` mock from `Button` tests and relax the class assertion to a regex (`/class="[^"]*button-link/`) so the test is robust to generated/scoped class names.  
- Add `components/__tests__/Project.test.js` with mocks for `react-plx` and `react-inlinesvg` and a rendering test that asserts presence of `href` and the scoped class names used by styles.

### Testing

- Ran the unit test suite with `npm test`; the updated `components/__tests__/Button.test.js` passed.  
- Added and ran `components/__tests__/Project.test.js`; the new test passed.  
- All component unit tests succeeded locally after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024881ab788330a96c217c681bc5c6)