### PR TITLE
fix: harden Button link detection and Video playback robustness

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -15,18 +15,40 @@ class Button extends Component {
   }
 
   isLinkInternal () {
-    if (!this.props.link)
+    if (!this.props.link || typeof this.props.link !== 'string')
       return false;
 
-    if (this.props.link.indexOf('://') === -1) {
+    const link = this.props.link.trim();
+
+    if (!link) {
+      return false;
+    }
+
+    if (link.startsWith('//')) {
+      return false;
+    }
+
+    if (
+      link.startsWith('/') ||
+      link.startsWith('./') ||
+      link.startsWith('../') ||
+      link.startsWith('#') ||
+      link.startsWith('?')
+    ) {
       return true;
     }
 
     try {
-      const url = new URL(this.props.link);
+      const url = new URL(link);
+
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return false;
+      }
+
       if (typeof window === 'undefined' || !window.location) {
         return false;
       }
+
       return window.location.host === url.host;
     } catch (e) {
       return false;
@@ -149,4 +171,3 @@ class Button extends Component {
 }
 
 export default Button;
-

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -22,7 +22,8 @@ class Navbar extends Component {
 
   updateProgress() {
     const height = document.documentElement.scrollHeight - window.innerHeight;
-    const value = height > 0 ? window.scrollY / height : 0;
+    const rawValue = height > 0 ? window.scrollY / height : 0;
+    const value = Number.isFinite(rawValue) ? Math.min(1, Math.max(0, rawValue)) : 0;
     this.setState({ progress: value });
   }
 

--- a/components/ProjectPage.js
+++ b/components/ProjectPage.js
@@ -12,9 +12,11 @@ class ProjectPage extends Component {
     super(props);
 
     const proj = new Projects();
+    const projectIdentifier = props.projectName || props.title;
+    const resolvedNextProject = proj.getNextProject(projectIdentifier) || proj.getRandomProject();
 
     this.state = {
-      nextProject: proj.getNextProject(props.title)
+      nextProject: resolvedNextProject
     };
 
 
@@ -28,7 +30,8 @@ class ProjectPage extends Component {
     hero: PropTypes.string.isRequired,
     heroAlt: PropTypes.string.isRequired,
     video: PropTypes.bool,
-    navbarColor: PropTypes.string
+    navbarColor: PropTypes.string,
+    projectName: PropTypes.string
   }
 
   static defaultProps = {
@@ -38,7 +41,8 @@ class ProjectPage extends Component {
     hero: "",
     heroAlt: "",
     video: false,
-    navbarColor: ""
+    navbarColor: "",
+    projectName: ""
   }
 
   render () {

--- a/components/Projects.js
+++ b/components/Projects.js
@@ -37,11 +37,17 @@ class Projects {
 
   getNextProject = (project) => {
     const index = this.getIndexOfProject(project);
+    if (index === -1) {
+      return null;
+    }
     return this.projects[(index + 1) % this.projects.length];
   };
 
   getPrevProject = (project) => {
     const index = this.getIndexOfProject(project);
+    if (index === -1) {
+      return null;
+    }
     return this.projects[(index - 1 + this.projects.length) % this.projects.length];
   };
 

--- a/components/Video.js
+++ b/components/Video.js
@@ -11,14 +11,16 @@ class Video extends Component {
 
   static propTypes = {
     autoplay: PropTypes.bool,
-    webMsrc: PropTypes.string.isRequired,
-    mp4src: PropTypes.string.isRequired,
+    src: PropTypes.string,
+    webMsrc: PropTypes.string,
+    mp4src: PropTypes.string,
     caption: PropTypes.string,
     controls: PropTypes.bool
   }
 
   static defaultProps = {
     autoplay: false,
+    src: "",
     webMsrc: "",
     mp4src: "",
     caption: "",
@@ -45,6 +47,10 @@ class Video extends Component {
   }
 
   render () {
+    const fallbackSrc = this.props.src || "";
+    const webMsrc = this.props.webMsrc || fallbackSrc;
+    const mp4src = this.props.mp4src || fallbackSrc;
+    const downloadSrc = mp4src || webMsrc || fallbackSrc;
 
     return (
       <span>
@@ -58,10 +64,10 @@ class Video extends Component {
           autoPlay={this.props.autoplay}
         >
 
-          <source src={this.props.webMsrc} type="video/webm" />
-          <source src={this.props.mp4src} type="video/mp4" />
+          <source src={webMsrc} type="video/webm" />
+          <source src={mp4src} type="video/mp4" />
 
-          <p>Your browser does not support the video tag. You can alternatively <a href={this.props.mp4src}>download</a> the video.</p>
+          <p>Your browser does not support the video tag. You can alternatively <a href={downloadSrc}>download</a> the video.</p>
         </video>
         {this.props.caption ?
           <p className={"caption"}>

--- a/components/Video.js
+++ b/components/Video.js
@@ -26,10 +26,21 @@ class Video extends Component {
   }
 
   playVideo = () => {
-    this._video.play();
+    if (!this._video || typeof this._video.play !== 'function') {
+      return;
+    }
+
+    const playPromise = this._video.play();
+    if (playPromise && typeof playPromise.catch === 'function') {
+      playPromise.catch(() => {});
+    }
   }
 
   stopVideo = () => {
+    if (!this._video || typeof this._video.pause !== 'function') {
+      return;
+    }
+
     this._video.pause();
   }
 
@@ -37,7 +48,15 @@ class Video extends Component {
 
     return (
       <span>
-        <video className={"video " + this.props.className} ref={(video) => { this._video = video; }} preload="meta" muted loop>
+        <video
+          className={"video " + this.props.className}
+          ref={(video) => { this._video = video; }}
+          preload="metadata"
+          muted
+          loop
+          controls={this.props.controls}
+          autoPlay={this.props.autoplay}
+        >
 
           <source src={this.props.webMsrc} type="video/webm" />
           <source src={this.props.mp4src} type="video/mp4" />
@@ -78,4 +97,3 @@ class Video extends Component {
 }
 
 export default Video;
-

--- a/components/__tests__/Button.test.js
+++ b/components/__tests__/Button.test.js
@@ -33,6 +33,23 @@ describe('Button.isLinkInternal', () => {
       global.window = originalWindow;
     }
   });
+
+  test('returns true for root-relative links when window is undefined (SSR)', () => {
+    const originalWindow = global.window;
+    global.window = undefined;
+
+    try {
+      const btn = new Button({ label: 'Test', link: '/projects', color: 'green' });
+      expect(btn.isLinkInternal()).toBe(true);
+    } finally {
+      global.window = originalWindow;
+    }
+  });
+
+  test('returns false for protocol-relative links', () => {
+    const btn = new Button({ label: 'Test', link: '//example.com/path', color: 'green' });
+    expect(btn.isLinkInternal()).toBe(false);
+  });
 });
 
 describe('Button rendering', () => {

--- a/components/__tests__/Navbar.test.js
+++ b/components/__tests__/Navbar.test.js
@@ -64,6 +64,28 @@ describe('Navbar reading progress', () => {
     expect(navbar.setState).toHaveBeenCalledWith({ progress: 0 });
   });
 
+  test('clamps progress to zero when scroll position is negative', () => {
+    document.documentElement = { scrollHeight: 1200 };
+    window.innerHeight = 200;
+    window.scrollY = -25;
+    const navbar = createNavbar();
+
+    navbar.updateProgress();
+
+    expect(navbar.setState).toHaveBeenCalledWith({ progress: 0 });
+  });
+
+  test('clamps progress to one when scroll position exceeds page height', () => {
+    document.documentElement = { scrollHeight: 1200 };
+    window.innerHeight = 200;
+    window.scrollY = 5000;
+    const navbar = createNavbar();
+
+    navbar.updateProgress();
+
+    expect(navbar.setState).toHaveBeenCalledWith({ progress: 1 });
+  });
+
   test('registers and removes progress listeners', () => {
     document.documentElement = { scrollHeight: 1000 };
     window.innerHeight = 500;

--- a/components/__tests__/Projects.test.js
+++ b/components/__tests__/Projects.test.js
@@ -20,4 +20,9 @@ describe('Projects navigation helpers', () => {
     expect(proj.getPrevProject(second.name)).toBe(first);
     expect(proj.getPrevProject(third.name)).toBe(second);
   });
+
+  test('returns null when navigating from unknown project name', () => {
+    expect(proj.getNextProject('Nonexistent Project')).toBeNull();
+    expect(proj.getPrevProject('Nonexistent Project')).toBeNull();
+  });
 });

--- a/components/__tests__/Video.test.js
+++ b/components/__tests__/Video.test.js
@@ -40,4 +40,16 @@ describe('Video rendering', () => {
     expect(markup).toContain('autoplay=""');
     expect(markup).toContain('preload="metadata"');
   });
+
+  test('uses src as fallback for webm and mp4 sources', () => {
+    const markup = renderToStaticMarkup(
+      <Video
+        src="/hero-video.mp4"
+      />
+    );
+
+    expect(markup).toContain('src="/hero-video.mp4" type="video/webm"');
+    expect(markup).toContain('src="/hero-video.mp4" type="video/mp4"');
+    expect(markup).toContain('href="/hero-video.mp4"');
+  });
 });

--- a/components/__tests__/Video.test.js
+++ b/components/__tests__/Video.test.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import Video from '../Video';
 
 describe('Video componentDidUpdate', () => {
@@ -13,5 +15,29 @@ describe('Video componentDidUpdate', () => {
     video.props = { autoplay: false, webMsrc: '', mp4src: '' };
     video.componentDidUpdate({ autoplay: true });
     expect(pause).toHaveBeenCalled();
+  });
+
+  test('does not throw when video ref is missing', () => {
+    const video = new Video({ autoplay: false, webMsrc: '', mp4src: '' });
+    expect(() => video.playVideo()).not.toThrow();
+    expect(() => video.stopVideo()).not.toThrow();
+  });
+});
+
+describe('Video rendering', () => {
+  test('passes controls and autoplay props to video element', () => {
+    const markup = renderToStaticMarkup(
+      <Video
+        autoplay
+        controls
+        className="vertical-video"
+        webMsrc="/demo.webm"
+        mp4src="/demo.mp4"
+      />
+    );
+
+    expect(markup).toContain('controls=""');
+    expect(markup).toContain('autoplay=""');
+    expect(markup).toContain('preload="metadata"');
   });
 });

--- a/pages/aikakone.js
+++ b/pages/aikakone.js
@@ -87,6 +87,7 @@ class Aikakone extends Component {
     return (
       <div className="Aikakone">
         <ProjectPage
+          projectName={"Aikakone"}
           title={"Aikakone"}
           hero={hero}
           heroAlt={"Ideation on canvas."}

--- a/pages/hri-study.js
+++ b/pages/hri-study.js
@@ -72,6 +72,7 @@ class Languagerobot extends Component {
     return (
       <div className="Languagerobot">
         <ProjectPage
+          projectName={"HRI Study"}
           title={"Human-Robot Interaction"}
           hero={pupils}
           heroAlt={"map"}

--- a/pages/kivakaupunki.js
+++ b/pages/kivakaupunki.js
@@ -83,6 +83,7 @@ class Kivakaupunki extends Component {
     return (
       <div className="KivaKaupunki">
         <ProjectPage
+          projectName={"Kiva Kaupunki"}
           title={"Kiva Kaupunki"}
           hero={hero}
           heroAlt={"map"}


### PR DESCRIPTION
### Motivation
- Prevent misclassification of links and fragile runtime errors during SSR and client playback by making link detection and video controls more defensive.
- Avoid runtime exceptions from missing refs or unhandled autoplay promise rejections and ensure component props actually affect the rendered `<video>` element.

### Description
- Hardened `Button.isLinkInternal` to validate input strings, trim whitespace, treat root-relative (`/`, `./`, `../`, `#`, `?`) links as internal, reject protocol-relative links (`//...`), and only consider `http`/`https` absolute URLs for same-host checks without erroneously relying on `window` during SSR.
- Updated `Video` to guard against missing `ref` before calling `play()`/`pause()`, to swallow rejected play promises safely, and to forward `controls`, `autoPlay`, and `preload="metadata"` onto the `<video>` element so props control behavior.
- Added tests for the Button fixes covering SSR root-relative behavior and protocol-relative URL rejection, and for the Video fixes covering missing-ref safety and rendered video attributes.

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all test suites passed (`26 passed, 26 total`).
- Built the site with `npm run build` and the Next.js production build and static export completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c637833083308da750fa8e64b57a)