### PR TITLE
Add security headers, SEO, PWA assets, accessibility and image optimizations

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,20 @@
-# 1 Month for most static assets
-<filesMatch ".(css|jpg|jpeg|png|gif|js|ico|svg|pdf)$">
-Header set Cache-Control "max-age=2592000, public"
+Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+Header always set X-Content-Type-Options "nosniff"
+Header always set Referrer-Policy "strict-origin-when-cross-origin"
+Header always set Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+Header always set X-Frame-Options "DENY"
+Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' mailto:"
+
+# 1 year for fingerprinted static assets
+<filesMatch "^.*\.(css|jpg|jpeg|png|gif|js|ico|svg|webmanifest|pdf)$">
+Header set Cache-Control "max-age=31536000, public, immutable"
 </filesMatch>
+
+# HTML should revalidate so metadata and redirects can update quickly
+<filesMatch "^.*\.html$">
+Header set Cache-Control "no-cache"
+</filesMatch>
+
 AddType image/svg+xml svg svgz
+AddType application/manifest+json webmanifest
 AddEncoding gzip svgz

--- a/components/Callout.js
+++ b/components/Callout.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 
 class Callout extends Component {
   static propTypes = {
@@ -64,7 +64,14 @@ class Callout extends Component {
     return (
       <div className={layout}>
         <div className={"callout-image-container " + this.props.className}>
-          <img src={resolveAssetSrc(this.props.image)} alt={this.props.altText} />
+          <img
+            src={resolveAssetSrc(this.props.image)}
+            alt={this.props.altText}
+            width={resolveAssetWidth(this.props.image)}
+            height={resolveAssetHeight(this.props.image)}
+            loading="lazy"
+            decoding="async"
+          />
         </div>
         <h5>{this.props.title}</h5>
         <p>

--- a/components/Lightbox.js
+++ b/components/Lightbox.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import { Carousel } from 'react-responsive-carousel';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 
 class Lightbox extends Component {
 
@@ -28,7 +28,14 @@ class Lightbox extends Component {
         <Carousel showThumbs={false} showStatus={false}>
           {this.props.images.map((img, i) => (
             <div key={i}>
-              <img src={resolveAssetSrc(img.src)} alt={img.caption || ''} />
+              <img
+                src={resolveAssetSrc(img.src)}
+                alt={img.caption || ''}
+                width={resolveAssetWidth(img.src)}
+                height={resolveAssetHeight(img.src)}
+                loading={i === 0 ? undefined : "lazy"}
+                decoding="async"
+              />
               {img.caption && <p className="legend">{img.caption}</p>}
             </div>
           ))}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -55,7 +55,7 @@ class Navbar extends Component {
 
   render() {
     return (
-      <div className="nav">
+      <header className="nav">
         <div className="progress-bar-wrap">
           <progress
             className={`progress-bar ${this.props.color}`}
@@ -64,7 +64,7 @@ class Navbar extends Component {
           />
         </div>
         <Headroom style={{ position: "fixed" }}>
-          <div className="navbar">
+          <nav className="navbar" aria-label="Primary navigation">
             <div className="links">
               <Link href="/" legacyBehavior>
                 <a className="navbar-link">Home</a>
@@ -100,7 +100,7 @@ class Navbar extends Component {
                 </div>
               ) : null}
             </div>
-          </div>
+          </nav>
         </Headroom>
         <style jsx>{`
           .headroom {
@@ -353,7 +353,7 @@ class Navbar extends Component {
 
 
     `}</style>
-      </div>
+      </header>
     );
   }
 }

--- a/components/Process.js
+++ b/components/Process.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 import first from '../static/media/icons/first.svg';
 import middle from '../static/media/icons/middle.svg';
 import last from '../static/media/icons/last.svg';
@@ -32,6 +32,14 @@ class Process extends Component {
                         (index === stepsLength - 1 ? last
                         : middle))}
                       alt={index + " step"}
+                      width={resolveAssetWidth(index === 0 ? first :
+                        (index === stepsLength - 1 ? last
+                        : middle))}
+                      height={resolveAssetHeight(index === 0 ? first :
+                        (index === stepsLength - 1 ? last
+                        : middle))}
+                      loading="lazy"
+                      decoding="async"
                     />
                   </div>
                   <li key={index} className="step-details">

--- a/components/Project.js
+++ b/components/Project.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
 import Isvg from 'react-inlinesvg';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 import { colors, shadows } from './design-system/tokens';
 import arrow from '../static/media/icons/arrow-slim.svg';
 
@@ -133,7 +133,15 @@ class Project extends Component {
       <Link href={this.props.link} className="project-link-container">
         <article className={`case-card ${this.props.color}`}>
           <div className="case-card__media">
-            <img className="case-card__image" src={resolveAssetSrc(this.props.image)} alt={this.props.alt} />
+            <img
+              className="case-card__image"
+              src={resolveAssetSrc(this.props.image)}
+              alt={this.props.alt}
+              width={resolveAssetWidth(this.props.image)}
+              height={resolveAssetHeight(this.props.image)}
+              loading="lazy"
+              decoding="async"
+            />
           </div>
           <div className="case-card__content">
             <h3 className="case-card__title">{this.props.title}</h3>

--- a/components/ProjectIcon.js
+++ b/components/ProjectIcon.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Isvg from 'react-inlinesvg';
 import Modal from 'react-modal';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 import HighlightUnderline from './design-system/HighlightUnderline';
 import close from '../static/media/icons/close.svg';
 
@@ -105,12 +105,21 @@ class ProjectIcon extends Component {
           contentLabel="Modal">
           <div>
             <button onClick={this.hideModal} className={"modal-close-button"}>
-              <img src={resolveAssetSrc(close)} alt={"close button"} style={{border: 0, height: '1.5em', width: '1.5em', background: 'var(--surface-elevated-color)'}}/>
+              <img src={resolveAssetSrc(close)} alt={"close button"} width="24" height="24" decoding="async" style={{border: 0, height: '1.5em', width: '1.5em', background: 'var(--surface-elevated-color)'}}/>
             </button>
             <h2>{this.props.title}</h2>
             <div className="modal-content">
               {this.props.description}
-              <img src={resolveAssetSrc(this.props.image)} alt={this.props.alt} onLoad={() => this.setState({imageLoaded: true})} loader={<div className={"loader"}></div> }/>
+              <img
+                src={resolveAssetSrc(this.props.image)}
+                alt={this.props.alt}
+                width={resolveAssetWidth(this.props.image)}
+                height={resolveAssetHeight(this.props.image)}
+                loading="lazy"
+                decoding="async"
+                onLoad={() => this.setState({imageLoaded: true})}
+                loader={<div className={"loader"}></div> }
+              />
               <div style={{marginTop: "1.5em"}}>
               {
                 (this.props.links).map(function (link, index){

--- a/components/ProjectPage.js
+++ b/components/ProjectPage.js
@@ -5,7 +5,7 @@ import Video from './Video';
 import Navbar from './Navbar';
 import Project from './Project';
 import Projects from './Projects';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 import { shadows } from './design-system/tokens';
 
 class ProjectPage extends Component {
@@ -79,10 +79,14 @@ class ProjectPage extends Component {
                   </div>
                 }
               </InViewport>
-              : <img  className="hero-image"
-                     src={resolveAssetSrc(this.props.hero)}
-                     alt={this.props.heroAlt}
-              />
+              : <img
+                  className="hero-image"
+                  src={resolveAssetSrc(this.props.hero)}
+                  alt={this.props.heroAlt}
+                  width={resolveAssetWidth(this.props.hero)}
+                  height={resolveAssetHeight(this.props.hero)}
+                  decoding="async"
+                />
             }
           </div>
         </div>

--- a/components/Seo.js
+++ b/components/Seo.js
@@ -1,0 +1,94 @@
+import Head from "next/head";
+
+const SITE_URL = "https://harritaito.com";
+const SITE_NAME = "Harri Halonen";
+
+const PAGE_METADATA = {
+  "/": {
+    title: "Harri Halonen | Product designer",
+    description:
+      "Portfolio of Harri Halonen, a Finnish experience designer shaping research-led services and humane digital products from Tampere.",
+    path: "/",
+  },
+  "/Home": {
+    title: "Harri Halonen | Product designer",
+    description:
+      "Portfolio of Harri Halonen, a Finnish experience designer shaping research-led services and humane digital products from Tampere.",
+    path: "/",
+  },
+  "/projects": {
+    title: "Projects | Harri Halonen",
+    description:
+      "Selected case studies from Harri Halonen across public services, healthcare, and emerging technology product design.",
+    path: "/projects",
+  },
+  "/about": {
+    title: "About | Harri Halonen",
+    description:
+      "Learn about Harri Halonen, an experience designer based in Tampere working across research, service design, and product strategy.",
+    path: "/about",
+  },
+  "/contact": {
+    title: "Contact | Harri Halonen",
+    description:
+      "Contact Harri Halonen for thoughtful collaborations, design conversations, and research-led product work.",
+    path: "/contact",
+  },
+  "/hri-study": {
+    title: "HRI study | Harri Halonen",
+    description:
+      "A classroom robot case study covering contextual inquiry, interviews, and theatrical prototyping for human-robot interaction.",
+    path: "/hri-study",
+  },
+  "/kivakaupunki": {
+    title: "Kiva Kaupunki | Harri Halonen",
+    description:
+      "A city feedback platform case study shaped through service design, interface sketches, and an MVP for civic reporting.",
+    path: "/kivakaupunki",
+  },
+  "/aikakone": {
+    title: "Aikakone | Harri Halonen",
+    description:
+      "A memory-care reminiscence service case study explored through field research, service blueprinting, and prototype sessions.",
+    path: "/aikakone",
+  },
+  "/404": {
+    title: "Page not found | Harri Halonen",
+    description:
+      "The requested page could not be found on Harri Halonen's portfolio.",
+    path: "/404",
+    noindex: true,
+  },
+};
+
+function normalizePath(pathname) {
+  if (!pathname || pathname === "/index") {
+    return "/";
+  }
+
+  return pathname.split("?")[0].replace(/\/$/, "") || "/";
+}
+
+export function getPageMetadata(pathname) {
+  const normalizedPath = normalizePath(pathname);
+  return PAGE_METADATA[normalizedPath] || PAGE_METADATA["/"];
+}
+
+export default function Seo({ pathname }) {
+  const metadata = getPageMetadata(pathname);
+  const canonicalUrl = `${SITE_URL}${metadata.path === "/" ? "/" : metadata.path}`;
+
+  return (
+    <Head>
+      <title>{metadata.title}</title>
+      <meta name="description" content={metadata.description} key="description" />
+      {metadata.noindex ? <meta name="robots" content="noindex, follow" key="robots" /> : null}
+      <link rel="canonical" href={canonicalUrl} key="canonical" />
+      <meta property="og:title" content={metadata.title} key="og-title" />
+      <meta property="og:description" content={metadata.description} key="og-description" />
+      <meta property="og:url" content={canonicalUrl} key="og-url" />
+      <meta name="twitter:title" content={metadata.title} key="twitter-title" />
+      <meta name="twitter:description" content={metadata.description} key="twitter-description" />
+    </Head>
+  );
+}

--- a/components/assetSource.js
+++ b/components/assetSource.js
@@ -9,3 +9,12 @@ export function resolveAssetSrc(asset) {
 
   return asset;
 }
+
+
+export function resolveAssetWidth(asset) {
+  return asset && typeof asset.width === 'number' ? asset.width : undefined;
+}
+
+export function resolveAssetHeight(asset) {
+  return asset && typeof asset.height === 'number' ? asset.height : undefined;
+}

--- a/pages/Home.js
+++ b/pages/Home.js
@@ -162,7 +162,7 @@ class Home extends Component {
           description="Led contextual inquiries, interviews, and usability studies to define how a teaching assistant robot should support classroom rituals and learning outcomes."
           image={languagerobot}
           link="/hri-study"
-          alt="Application for city reporting"
+          alt="Classroom robot research and prototyping"
           color="red"
           label="Archive case study"
           percentage="8%"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,13 +1,49 @@
 import { useEffect } from "react";
+import { useRouter } from "next/router";
 import Fonts from "../components/Fonts";
+import Seo from "../components/Seo";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import "react-medium-image-zoom/dist/styles.css";
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
   useEffect(() => {
     Fonts();
   }, []);
-  return <Component {...pageProps} />;
+
+  return (
+    <>
+      <Seo pathname={router.pathname} />
+      <a className="skip-link" href="#main-content">
+        Skip to main content
+      </a>
+      <main id="main-content">
+        <Component {...pageProps} />
+      </main>
+      <style jsx global>{`
+        .skip-link {
+          background: var(--surface-elevated-color);
+          border: 2px solid var(--focus-outline);
+          border-radius: 999px;
+          color: var(--link-color);
+          left: 1rem;
+          padding: 0.65rem 1rem;
+          position: fixed;
+          top: 1rem;
+          transform: translateY(-200%);
+          transition: transform 0.2s ease;
+          z-index: 1000;
+        }
+
+        .skip-link:focus,
+        .skip-link:focus-visible {
+          outline: none;
+          transform: translateY(0);
+        }
+      `}</style>
+    </>
+  );
 }
 
 export default MyApp;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -2,11 +2,8 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 import Fonts from "../components/Fonts";
 
 const SITE_METADATA = Object.freeze({
-  title: "Harri Halonen",
-  description:
-    "Portfolio of Harri Halonen, a Finnish experience designer shaping research-led services and humane digital products from Tampere.",
-  siteUrl: "https://harritaito.com/",
   locale: "en_US",
+  siteName: "Harri Halonen",
   twitterHandle: "@harritaito",
   socialImage: {
     url: "https://harritaito.com/static/media/twittericon.png",
@@ -39,8 +36,7 @@ export default class MyDocument extends Document {
       }
     )();`;
 
-    const { title, description, siteUrl, locale, twitterHandle, socialImage } =
-      SITE_METADATA;
+    const { locale, siteName, twitterHandle, socialImage } = SITE_METADATA;
 
     return (
       <Html lang="en">
@@ -51,8 +47,7 @@ export default class MyDocument extends Document {
             name="viewport"
             content="width=device-width, initial-scale=1, viewport-fit=cover"
           />
-          <meta name="description" content={description} />
-          <link rel="canonical" href={siteUrl} />
+          <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
           <link
             rel="icon"
             sizes="192x192"
@@ -61,20 +56,18 @@ export default class MyDocument extends Document {
           <link rel="apple-touch-icon" href="/static/media/touch-icon.png" />
           <link
             rel="mask-icon"
-            href="/static/favicon-mask.svg"
+            href="/favicon-mask.svg"
             color="#49B882"
           />
           <link rel="icon" href="/static/favicon.ico" />
-          <meta property="og:url" content={siteUrl} />
+          <link rel="manifest" href="/manifest.webmanifest" />
+          <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
+          <meta name="theme-color" content="#0b1120" media="(prefers-color-scheme: dark)" />
           <meta property="og:type" content="website" />
-          <meta property="og:title" content={title} />
-          <meta property="og:site_name" content={title} />
-          <meta property="og:description" content={description} />
+          <meta property="og:site_name" content={siteName} />
           <meta property="og:locale" content={locale} />
           <meta name="twitter:site" content={twitterHandle} />
           <meta name="twitter:creator" content={twitterHandle} />
-          <meta name="twitter:title" content={title} />
-          <meta name="twitter:description" content={description} />
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:image" content={socialImage.url} />
           <meta name="twitter:image:alt" content={socialImage.alt} />

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Head from 'next/head';
 import Link from 'next/link';
 import Row from '../components/Row';
 import HighlightUnderline from '../components/design-system/HighlightUnderline';
@@ -9,6 +10,15 @@ class PageNotFound extends Component {
 
     return (
       <div className="PageNotFound container">
+        <Head>
+          <title>Page not found | Harri Halonen</title>
+          <meta name="description" content="The requested page could not be found on Harri Halonen's portfolio." key="description" />
+          <meta name="robots" content="noindex, follow" key="robots" />
+          <link rel="canonical" href="https://harritaito.com/404" key="canonical" />
+          <meta property="og:title" content="Page not found | Harri Halonen" key="og-title" />
+          <meta property="og:description" content="The requested page could not be found on Harri Halonen's portfolio." key="og-description" />
+          <meta property="og:url" content="https://harritaito.com/404" key="og-url" />
+        </Head>
         <div className="pohja">
         </div>
         <Row content={

--- a/pages/about.js
+++ b/pages/about.js
@@ -16,7 +16,7 @@ class About extends Component {
             content={
               <div className="my-photo-container col-xs-12 col-sm-12 col-md-12 col-lg-12 col-xl-12">
                 <div className={"my-photo"}>
-                  <img src="../static/media/about/me.jpg" alt={"Me"} />
+                  <img src="../static/media/about/me.jpg" alt={"Harri Halonen"} width="275" height="275" decoding="async" />
                 </div>
               </div>
             }

--- a/pages/aikakone.js
+++ b/pages/aikakone.js
@@ -7,7 +7,7 @@ import Process from "../components/Process";
 import ProjectStats from "../components/ProjectStats";
 import ProjectSection from "../components/ProjectSection";
 import Row from "../components/Row";
-import { resolveAssetSrc } from "../components/assetSource";
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from "../components/assetSource";
 import HighlightUnderline from "../components/design-system/HighlightUnderline";
 import { colors, shadows } from "../components/design-system/tokens";
 import { Carousel } from "react-responsive-carousel";
@@ -415,19 +415,19 @@ class Aikakone extends Component {
                       <Modal isOpen={modalIsOpen} onRequestClose={this.toggleModal}>
                         <Carousel showThumbs={false} showStatus={false} selectedItem={this.state.selectedSlideIndex}>
                           <div>
-                            <img src={resolveAssetSrc(menu)} alt="First look of the menu of Aikakone." />
+                            <img src={resolveAssetSrc(menu)} alt="First look of the menu of Aikakone." width={resolveAssetWidth(menu)} height={resolveAssetHeight(menu)} decoding="async" />
                             <p className="legend">First look of the menu of Aikakone.</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(aikakone)} alt="Using Aikakone" />
+                            <img src={resolveAssetSrc(aikakone)} alt="Using Aikakone" width={resolveAssetWidth(aikakone)} height={resolveAssetHeight(aikakone)} loading="lazy" decoding="async" />
                             <p className="legend">Using Aikakone</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(profile)} alt="Profile of elderly people" />
+                            <img src={resolveAssetSrc(profile)} alt="Profile of elderly people" width={resolveAssetWidth(profile)} height={resolveAssetHeight(profile)} loading="lazy" decoding="async" />
                             <p className="legend">Profile of elderly people</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(elamankaari)} alt="Elämänkaari, a feature that has the lifespan of induvidual user" />
+                            <img src={resolveAssetSrc(elamankaari)} alt="Elämänkaari, a feature that has the lifespan of induvidual user" width={resolveAssetWidth(elamankaari)} height={resolveAssetHeight(elamankaari)} loading="lazy" decoding="async" />
                             <p className="legend">Elämänkaari, a feature that has the lifespan of induvidual user</p>
                           </div>
                         </Carousel>
@@ -445,7 +445,7 @@ class Aikakone extends Component {
                               "col-xs-4 col-sm-4 col-md-2 col-lg-2 col-xl-2"
                             }
                           >
-                            <img className="mini-image" src={resolveAssetSrc(image)} alt="" />
+                            <img className="mini-image" src={resolveAssetSrc(image)} alt="" width={resolveAssetWidth(image)} height={resolveAssetHeight(image)} loading="lazy" decoding="async" />
                           </div>
                         );
                       })}

--- a/pages/kivakaupunki.js
+++ b/pages/kivakaupunki.js
@@ -8,7 +8,7 @@ import Process from '../components/Process';
 import ProjectStats from '../components/ProjectStats';
 import ProjectSection from "../components/ProjectSection";
 import Row from '../components/Row';
-import { resolveAssetSrc } from '../components/assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from '../components/assetSource';
 import HighlightUnderline from '../components/design-system/HighlightUnderline';
 import { colors, shadows } from '../components/design-system/tokens';
 import { Carousel } from 'react-responsive-carousel';
@@ -224,27 +224,27 @@ class Kivakaupunki extends Component {
                       <Modal isOpen={modalIsOpen} onRequestClose={this.toggleModal}>
                         <Carousel showThumbs={false} showStatus={false} selectedItem={this.state.selectedSlideIndex}>
                           <div>
-                            <img src={resolveAssetSrc(phone)} alt="Start greeting scene of app" />
+                            <img src={resolveAssetSrc(phone)} alt="Start greeting scene of app" width={resolveAssetWidth(phone)} height={resolveAssetHeight(phone)} decoding="async" />
                             <p className="legend">Start greeting scene of app</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(phone_booth)} alt="Location tagging by gps or by selecting and tapping." />
+                            <img src={resolveAssetSrc(phone_booth)} alt="Location tagging by gps or by selecting and tapping." width={resolveAssetWidth(phone_booth)} height={resolveAssetHeight(phone_booth)} loading="lazy" decoding="async" />
                             <p className="legend">Location tagging by gps or by selecting and tapping.</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(physical)} alt="Second screen, notice the return button" />
+                            <img src={resolveAssetSrc(physical)} alt="Second screen, notice the return button" width={resolveAssetWidth(physical)} height={resolveAssetHeight(physical)} loading="lazy" decoding="async" />
                             <p className="legend">Second screen, notice the return button</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(popup)} alt="Comment categories" />
+                            <img src={resolveAssetSrc(popup)} alt="Comment categories" width={resolveAssetWidth(popup)} height={resolveAssetHeight(popup)} loading="lazy" decoding="async" />
                             <p className="legend">Comment categories</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(watch)} alt="Comment input" />
+                            <img src={resolveAssetSrc(watch)} alt="Comment input" width={resolveAssetWidth(watch)} height={resolveAssetHeight(watch)} loading="lazy" decoding="async" />
                             <p className="legend">Comment input</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(footsteps)} alt="Final thank you screen" />
+                            <img src={resolveAssetSrc(footsteps)} alt="Final thank you screen" width={resolveAssetWidth(footsteps)} height={resolveAssetHeight(footsteps)} loading="lazy" decoding="async" />
                             <p className="legend">Final thank you screen</p>
                           </div>
                         </Carousel>
@@ -254,7 +254,7 @@ class Kivakaupunki extends Component {
                     <Row className="one-margin-top" content={views.map(function (image, index) {
                         return (
                           <div key={"sketch" + index} onClick={(e) => self.toggleModal(index, e)} className={"col-xs-4 col-sm-4 col-md-2 col-lg-2 col-xl-2"}>
-                            <img className="mini-image" src={resolveAssetSrc(image)} alt=""/>
+                            <img className="mini-image" src={resolveAssetSrc(image)} alt="" width={resolveAssetWidth(image)} height={resolveAssetHeight(image)} loading="lazy" decoding="async" />
                           </div>
                         )
                       })

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,13 @@
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()
+  X-Frame-Options: DENY
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' mailto:
+
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/static/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/public/favicon-mask.svg
+++ b/public/favicon-mask.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path fill="#000" d="M17 46V18h7v11h16V18h7v28h-7V35H24v11h-7Z"/>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Harri Halonen">
+  <rect width="64" height="64" rx="16" fill="#0f172a"/>
+  <path fill="#49B882" d="M17 46V18h7v11h16V18h7v28h-7V35H24v11h-7Z"/>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "Harri Halonen",
+  "short_name": "Harri",
+  "description": "Portfolio of Harri Halonen, a Finnish experience designer shaping research-led services and humane digital products.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "minimal-ui",
+  "background_color": "#fafafa",
+  "theme_color": "#49B882",
+  "icons": [
+    {
+      "src": "/static/media/touch-icon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/media/touch-icon.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,13 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+Sitemap: https://harritaito.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://harritaito.com/</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/projects</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/about</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/contact</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/hri-study</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/kivakaupunki</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/aikakone</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
### Motivation
- Improve site security and caching by adding HTTP security headers and long-lived caching for immutable assets.
- Improve SEO and social metadata with a centralized `Seo` component and canonical/OG tags, and expose a sitemap/robots for crawlers.
- Improve accessibility and perceived performance by adding skip-links, semantic landmarks, and explicit image sizing and lazy/async decoding.

### Description
- Added HTTP headers and caching rules in `.htaccess` and a Netlify-style `public/_headers`, plus added `Content-Security-Policy`, `Strict-Transport-Security`, and other security headers. 
- Added PWA and static files: `public/manifest.webmanifest`, `public/favicon.svg`, `public/favicon-mask.svg`, `public/_headers`, `public/robots.txt`, and `public/sitemap.xml`, and wired the manifest and icons in `_document.js`.
- Introduced a new `components/Seo.js` with a page metadata map and integrated it into `pages/_app.js`; also added page-level meta tags for the 404 page and updated `_document.js` meta/theme handling.
- Added `resolveAssetWidth` and `resolveAssetHeight` to `components/assetSource.js` and updated numerous components (`Callout`, `Lightbox`, `Process`, `Project`, `ProjectIcon`, `ProjectPage`, various pages) to include `width`, `height`, `loading`, and `decoding` attributes on `<img>` elements for better layout stability and performance.
- Improved semantics and accessibility by changing the navbar wrapper to `<header>`/`<nav>` with `aria-label`, and adding a keyboard-accessible skip link in `_app.js`.

### Testing
- Ran `npm run lint` to check code style and common issues and it completed successfully.
- Ran a production Next.js build with `npm run build` and the build succeeded.
- No failing automated tests were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c67c0573c8330954b127a98fa54d5)