### PR TITLE
Contextualize older portfolio work

### DIFF
--- a/components/Projects.js
+++ b/components/Projects.js
@@ -12,7 +12,7 @@ class Projects {
       link: "/hri-study",
       alt: "Human-Robot Interaction",
       color: "red",
-      label: "Older work"
+      label: "Older selected work"
     },
     {
       name: "Kiva Kaupunki",
@@ -21,7 +21,7 @@ class Projects {
       link: "/kivakaupunki",
       alt: "Application for city reporting",
       color: "blue",
-      label: "Older work"
+      label: "Archive / older work"
     },
     {
       name: "Aikakone",
@@ -30,7 +30,7 @@ class Projects {
       link: "/aikakone",
       alt: "Concept service for memory care",
       color: "purple",
-      label: "Older work"
+      label: "Older selected work"
     },
   ];
 

--- a/pages/Home.js
+++ b/pages/Home.js
@@ -7,7 +7,6 @@ import HighlightUnderline from "../components/design-system/HighlightUnderline";
 import { colors, radii } from "../components/design-system/tokens";
 
 import languagerobot from "../static/media/home/languagerobot.jpg";
-import kivakaupunki from "../static/media/home/kivakaupunki.jpg";
 import aikakone from "../static/media/home/aikakone.jpg";
 
 class Home extends Component {
@@ -114,7 +113,7 @@ class Home extends Component {
           <Row
             content={
               <p className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 section-subheading">
-                Three selected case studies that show the range without overfilling the page. Older work stays accessible in the archive so it does not set the tone for the whole site.
+                Two older selected cases stay featured because they show the clearest process evidence: research, synthesis, service thinking, and design decisions under real constraints. Newer case-study material is in development, so older work is labeled clearly instead of being presented as recent.
               </p>
             }
           />
@@ -123,19 +122,9 @@ class Home extends Component {
             description="Used contextual inquiry, teacher interviews, and theatrical prototyping to define how a teaching-assistant robot could better fit classroom rituals."
             image={languagerobot}
             link="/hri-study"
-            alt="Application for city reporting"
+            alt="Children interacting with a teaching-assistant robot"
             color="red"
-            label="Older work"
-            percentage="8%"
-          />
-          <Project
-            title="Kiva Kaupunki"
-            description="Shaped a city feedback concept from civic problem framing into a map-based MVP through service design, interface sketches, and implementation support."
-            image={kivakaupunki}
-            link="/kivakaupunki"
-            alt="Application for city reporting"
-            color="blue"
-            label="Older work"
+            label="Older selected work"
             percentage="8%"
           />
           <Project
@@ -145,8 +134,22 @@ class Home extends Component {
             link="/aikakone"
             alt="Concept service for memory care"
             color="purple"
-            label="Older work"
+            label="Older selected work"
             percentage="28%"
+          />
+          <Row
+            content={
+              <p className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 section-subheading archive-note">
+                Kiva Kaupunki and earlier community, course, and volunteer projects remain available in the archive as foundations and supporting process evidence.
+                <span className="section-inline-link">
+                  {" "}
+                  <Link href="/projects" as="/projects">
+                    Open the archive.
+                    <HighlightUnderline />
+                  </Link>
+                </span>
+              </p>
+            }
           />
         </section>
 
@@ -437,6 +440,10 @@ class Home extends Component {
 
           .Home .section-subheading {
             margin-bottom: 2.5em;
+          }
+
+          .Home .archive-note {
+            margin-top: -2.5em;
           }
 
           .Home .section-list {

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -16,9 +16,16 @@ const ProjectsPage = () => {
           <div className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 archive-intro">
             <h1>Archive</h1>
             <p>
-              Older work and community projects live here for reference. The selected work on the homepage carries the main narrative; this page keeps the rest accessible without competing with it.
+              Older selected work stays here because it still shows useful thinking, process, artifacts, and constraints. HRI Study and Aikakone remain the strongest archive cases while newer case-study material is being developed; Kiva Kaupunki is kept as supporting evidence for civic MVP and implementation work.
             </p>
           </div>
+        }
+      />
+      <Row
+        content={
+          <h2 className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 archive-heading archive-heading-first">
+            Selected older cases
+          </h2>
         }
       />
       {projects.map((p) => (
@@ -37,14 +44,14 @@ const ProjectsPage = () => {
       <Row
         content={
           <h2 className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 archive-heading">
-            Earlier archive
+            Foundations
           </h2>
         }
       />
       <Row
         content={
           <p className="col-xs-12 col-sm-10 col-md-9 col-lg-8 col-xl-7 archive-copy">
-            Community, course, and volunteer notes kept as provenance for older work.
+            Earlier community, course, and volunteer work is kept as provenance: useful context for facilitation, collaboration, and early service-design practice, without making it the lead professional signal.
           </p>
         }
       />
@@ -74,6 +81,10 @@ const ProjectsPage = () => {
         .archive-heading {
           margin-top: 4rem;
           margin-bottom: 0.25rem;
+        }
+
+        .archive-heading-first {
+          margin-top: 3rem;
         }
 
         .archive-copy {


### PR DESCRIPTION
Keep older cases accessible without letting them read as recent.\n\n- Feature HRI Study and Aikakone as older selected work on the homepage.\n- Move Kiva Kaupunki to archive/supporting evidence labeling.\n- Add archive copy that explains older cases remain for process evidence while newer case-study material is being developed.