### PR TITLE
fix: migrate to official GitHub Pages Actions deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,15 @@ on:
     branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build and Test
@@ -17,6 +26,8 @@ jobs:
         with:
           node-version: '20.9.0'
           cache: 'npm'
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Install dependencies
         run: npm ci
       - name: Run tests
@@ -25,26 +36,19 @@ jobs:
         run: npm run build
       - name: Verify static export
         run: npm run verify:out
-      - name: Upload production build artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: next-out
           path: out
+
   deploy:
     name: Publish to GitHub Pages
     runs-on: ubuntu-latest
     needs: build
-    permissions:
-      contents: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Download production build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: next-out
-          path: out
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replaces peaceiris/actions-gh-pages (which pushes to the gh-pages branch
but does not update the Pages source configuration) with the official
actions/configure-pages + actions/upload-pages-artifact + actions/deploy-pages
stack. This correctly registers deployments through the GitHub Pages API
and resolves the 404 caused by Pages serving from master instead of gh-pages.

https://claude.ai/code/session_019diyHN4NEifBKwK3HcAjx9