### PR TITLE
Simplify top nav: Home on left, next page link on right

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -128,9 +128,9 @@ class Navbar extends Component {
           .headroom--unfixed .progress-bar-wrap {
             display: none;
           }
-          .headroom-wrapper{height: 1rem;}
+          .headroom-wrapper{height: 3.5rem;}
           .navbar {
-            padding: 0.75em 1em;
+            padding: 1em 1.5em 0.75em;
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -265,7 +265,7 @@ class Navbar extends Component {
 
           @media only screen and (max-width: 575px) {
             .navbar {
-              padding: 0.6em 0.75em;
+              padding: 0.75em 1em 0.6em;
             }
           }
 


### PR DESCRIPTION
## Summary

- Replaced the full navigation menu (7 links + theme toggle) with just a **Home** link on the left
- The right side shows the optional "next page" link with arrow, only when `nextProjectLink` is provided
- Restored navbar height/padding to match the original proportions (`1em 1.5em 0.75em`)
- Removed the `links` prop and `ThemeToggle` import — component is now minimal

## Test plan

- [ ] Visit a page that uses `<Navbar nextProjectLink={null} />` (e.g. `/about`, `/contact`, `/projects`) — should show only "Home" on the left, nothing on the right
- [ ] Visit a page with a `nextProjectLink` set — should show "Home" on the left and the named link with arrow on the right
- [ ] Confirm navbar height feels visually balanced (not too short/tall)
- [ ] Check mobile layout at < 575px width

https://claude.ai/code/session_01MuZZNyMZw94KorRMtemqFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuZZNyMZw94KorRMtemqFZ)_