### PR TITLE
Add cache busting for bare-path static assets

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  env: {
+    NEXT_PUBLIC_BUILD_ID: Date.now().toString(),
+  },
   reactStrictMode: true,
   output: "export",
   outputFileTracingRoot: __dirname,

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,8 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import Fonts from "../components/Fonts";
 
+const v = process.env.NEXT_PUBLIC_BUILD_ID;
+
 const SITE_METADATA = Object.freeze({
   title: "Harri Halonen",
   description:
@@ -56,15 +58,15 @@ export default class MyDocument extends Document {
           <link
             rel="icon"
             sizes="192x192"
-            href="/static/media/touch-icon.png"
+            href={`/static/media/touch-icon.png?v=${v}`}
           />
-          <link rel="apple-touch-icon" href="/static/media/touch-icon.png" />
+          <link rel="apple-touch-icon" href={`/static/media/touch-icon.png?v=${v}`} />
           <link
             rel="mask-icon"
-            href="/static/favicon-mask.svg"
+            href={`/static/favicon-mask.svg?v=${v}`}
             color="#49B882"
           />
-          <link rel="icon" href="/static/favicon.ico" />
+          <link rel="icon" href={`/static/favicon.ico?v=${v}`} />
           <meta property="og:url" content={siteUrl} />
           <meta property="og:type" content="website" />
           <meta property="og:title" content={title} />

--- a/pages/about.js
+++ b/pages/about.js
@@ -4,6 +4,8 @@ import Footer from "../components/Footer";
 import Navbar from "../components/Navbar";
 import HighlightUnderline from "../components/design-system/HighlightUnderline";
 import { colors, radii } from "../components/design-system/tokens";
+import mePhoto from "../static/media/about/me.jpg";
+import { resolveAssetSrc } from "../components/assetSource";
 
 class About extends Component {
   render() {
@@ -16,7 +18,7 @@ class About extends Component {
             content={
               <div className="my-photo-container col-xs-12 col-sm-12 col-md-12 col-lg-12 col-xl-12">
                 <div className={"my-photo"}>
-                  <img src="../static/media/about/me.jpg" alt={"Me"} />
+                  <img src={resolveAssetSrc(mePhoto)} alt={"Me"} />
                 </div>
               </div>
             }


### PR DESCRIPTION
JS/CSS chunks already have content-hash filenames via Next.js. This fills
the remaining gaps: favicons in _document.js get a build-timestamp query
string (?v=NEXT_PUBLIC_BUILD_ID), and the bare-path me.jpg in about.js is
replaced with an ES6 import + resolveAssetSrc() to route it through
webpack's content-hash pipeline like all other page images.

https://claude.ai/code/session_018THYNwUNsd4wfqe2Ns2nCQ