### PR TITLE
Add SEO, accessibility and image optimizations; add webmanifest, robots and sitemap

### DIFF
--- a/components/Callout.js
+++ b/components/Callout.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 
 class Callout extends Component {
   static propTypes = {
@@ -64,7 +64,14 @@ class Callout extends Component {
     return (
       <div className={layout}>
         <div className={"callout-image-container " + this.props.className}>
-          <img src={resolveAssetSrc(this.props.image)} alt={this.props.altText} />
+          <img
+            src={resolveAssetSrc(this.props.image)}
+            alt={this.props.altText}
+            width={resolveAssetWidth(this.props.image)}
+            height={resolveAssetHeight(this.props.image)}
+            loading="lazy"
+            decoding="async"
+          />
         </div>
         <h5>{this.props.title}</h5>
         <p>

--- a/components/Lightbox.js
+++ b/components/Lightbox.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import { Carousel } from 'react-responsive-carousel';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 
 class Lightbox extends Component {
 
@@ -28,7 +28,14 @@ class Lightbox extends Component {
         <Carousel showThumbs={false} showStatus={false}>
           {this.props.images.map((img, i) => (
             <div key={i}>
-              <img src={resolveAssetSrc(img.src)} alt={img.caption || ''} />
+              <img
+                src={resolveAssetSrc(img.src)}
+                alt={img.caption || ''}
+                width={resolveAssetWidth(img.src)}
+                height={resolveAssetHeight(img.src)}
+                loading={i === 0 ? undefined : "lazy"}
+                decoding="async"
+              />
               {img.caption && <p className="legend">{img.caption}</p>}
             </div>
           ))}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -54,7 +54,7 @@ class Navbar extends Component {
 
   render() {
     return (
-      <div className="nav">
+      <header className="nav">
         <div className="progress-bar-wrap">
           <progress
             className={`progress-bar ${this.props.color}`}
@@ -63,7 +63,7 @@ class Navbar extends Component {
           />
         </div>
         <Headroom style={{ position: "fixed" }}>
-          <div className="navbar">
+          <nav className="navbar" aria-label="Primary navigation">
             <Link href="/" legacyBehavior>
               <a className="navbar-link">Home</a>
             </Link>
@@ -80,7 +80,7 @@ class Navbar extends Component {
                 </Link>
               </div>
             ) : null}
-          </div>
+          </nav>
         </Headroom>
         <style jsx>{`
           .headroom {
@@ -295,7 +295,7 @@ class Navbar extends Component {
 
 
     `}</style>
-      </div>
+      </header>
     );
   }
 }

--- a/components/Process.js
+++ b/components/Process.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 import first from '../static/media/icons/first.svg';
 import middle from '../static/media/icons/middle.svg';
 import last from '../static/media/icons/last.svg';
@@ -32,6 +32,14 @@ class Process extends Component {
                         (index === stepsLength - 1 ? last
                         : middle))}
                       alt={index + " step"}
+                      width={resolveAssetWidth(index === 0 ? first :
+                        (index === stepsLength - 1 ? last
+                        : middle))}
+                      height={resolveAssetHeight(index === 0 ? first :
+                        (index === stepsLength - 1 ? last
+                        : middle))}
+                      loading="lazy"
+                      decoding="async"
                     />
                   </div>
                   <li key={index} className="step-details">

--- a/components/Project.js
+++ b/components/Project.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
 import Isvg from 'react-inlinesvg';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 import { colors, shadows } from './design-system/tokens';
 import arrow from '../static/media/icons/arrow-slim.svg';
 
@@ -135,7 +135,15 @@ class Project extends Component {
       <Link href={this.props.link} className="project-link-container">
         <article className={`case-card ${this.props.color}`}>
           <div className="case-card__media">
-            <img className="case-card__image" src={resolveAssetSrc(this.props.image)} alt={this.props.alt} />
+            <img
+              className="case-card__image"
+              src={resolveAssetSrc(this.props.image)}
+              alt={this.props.alt}
+              width={resolveAssetWidth(this.props.image)}
+              height={resolveAssetHeight(this.props.image)}
+              loading="lazy"
+              decoding="async"
+            />
           </div>
           <div className="case-card__content">
             <h3 className="case-card__title">{this.props.title}</h3>

--- a/components/ProjectIcon.js
+++ b/components/ProjectIcon.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Isvg from 'react-inlinesvg';
 import Modal from 'react-modal';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 import HighlightUnderline from './design-system/HighlightUnderline';
 import close from '../static/media/icons/close.svg';
 
@@ -105,12 +105,21 @@ class ProjectIcon extends Component {
           contentLabel="Modal">
           <div>
             <button onClick={this.hideModal} className={"modal-close-button"}>
-              <img src={resolveAssetSrc(close)} alt={"close button"} style={{border: 0, height: '1.5em', width: '1.5em', background: 'var(--surface-elevated-color)'}}/>
+              <img src={resolveAssetSrc(close)} alt={"close button"} width="24" height="24" decoding="async" style={{border: 0, height: '1.5em', width: '1.5em', background: 'var(--surface-elevated-color)'}}/>
             </button>
             <h2>{this.props.title}</h2>
             <div className="modal-content">
               {this.props.description}
-              <img src={resolveAssetSrc(this.props.image)} alt={this.props.alt} onLoad={() => this.setState({imageLoaded: true})} loader={<div className={"loader"}></div> }/>
+              <img
+                src={resolveAssetSrc(this.props.image)}
+                alt={this.props.alt}
+                width={resolveAssetWidth(this.props.image)}
+                height={resolveAssetHeight(this.props.image)}
+                loading="lazy"
+                decoding="async"
+                onLoad={() => this.setState({imageLoaded: true})}
+                loader={<div className={"loader"}></div> }
+              />
               <div style={{marginTop: "1.5em"}}>
               {
                 (this.props.links).map(function (link, index){

--- a/components/ProjectPage.js
+++ b/components/ProjectPage.js
@@ -5,7 +5,7 @@ import Video from './Video';
 import Navbar from './Navbar';
 import Project from './Project';
 import Projects from './Projects';
-import { resolveAssetSrc } from './assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from './assetSource';
 import { shadows } from './design-system/tokens';
 
 class ProjectPage extends Component {
@@ -79,10 +79,14 @@ class ProjectPage extends Component {
                   </div>
                 }
               </InViewport>
-              : <img  className="hero-image"
-                     src={resolveAssetSrc(this.props.hero)}
-                     alt={this.props.heroAlt}
-              />
+              : <img
+                  className="hero-image"
+                  src={resolveAssetSrc(this.props.hero)}
+                  alt={this.props.heroAlt}
+                  width={resolveAssetWidth(this.props.hero)}
+                  height={resolveAssetHeight(this.props.hero)}
+                  decoding="async"
+                />
             }
           </div>
         </div>

--- a/components/Seo.js
+++ b/components/Seo.js
@@ -1,0 +1,101 @@
+import Head from "next/head";
+
+const SITE_URL = "https://harritaito.com";
+const SITE_NAME = "Harri Halonen";
+
+const PAGE_METADATA = {
+  "/": {
+    title: "Harri Halonen | Product designer",
+    description:
+      "Portfolio of Harri Halonen, a Finnish experience designer shaping research-led services and humane digital products from Tampere.",
+    path: "/",
+  },
+  "/Home": {
+    title: "Harri Halonen | Product designer",
+    description:
+      "Portfolio of Harri Halonen, a Finnish experience designer shaping research-led services and humane digital products from Tampere.",
+    path: "/",
+  },
+  "/projects": {
+    title: "Projects | Harri Halonen",
+    description:
+      "Selected case studies from Harri Halonen across industrial XR, public services, healthcare, and emerging technology product design.",
+    path: "/projects",
+  },
+  "/about": {
+    title: "About | Harri Halonen",
+    description:
+      "Learn about Harri Halonen, an experience designer based in Tampere working across research, service design, and product strategy.",
+    path: "/about",
+  },
+  "/contact": {
+    title: "Contact | Harri Halonen",
+    description:
+      "Contact Harri Halonen for thoughtful collaborations, design conversations, and research-led product work.",
+    path: "/contact",
+  },
+  "/thesis": {
+    title: "Industrial XR thesis | Harri Halonen",
+    description:
+      "A master's thesis case study on interaction design principles for demanding industrial XR environments.",
+    path: "/thesis",
+  },
+  "/hri-study": {
+    title: "HRI study | Harri Halonen",
+    description:
+      "A classroom robot case study covering contextual inquiry, interviews, and theatrical prototyping for human-robot interaction.",
+    path: "/hri-study",
+  },
+  "/kivakaupunki": {
+    title: "Kiva Kaupunki | Harri Halonen",
+    description:
+      "A city feedback platform case study shaped through service design, interface sketches, and an MVP for civic reporting.",
+    path: "/kivakaupunki",
+  },
+  "/aikakone": {
+    title: "Aikakone | Harri Halonen",
+    description:
+      "A memory-care reminiscence service case study explored through field research, service blueprinting, and prototype sessions.",
+    path: "/aikakone",
+  },
+  "/404": {
+    title: "Page not found | Harri Halonen",
+    description:
+      "The requested page could not be found on Harri Halonen's portfolio.",
+    path: "/404",
+    noindex: true,
+  },
+};
+
+function normalizePath(pathname) {
+  if (!pathname || pathname === "/index") {
+    return "/";
+  }
+
+  return pathname.split("?")[0].replace(/\/$/, "") || "/";
+}
+
+export function getPageMetadata(pathname) {
+  const normalizedPath = normalizePath(pathname);
+  return PAGE_METADATA[normalizedPath] || PAGE_METADATA["/"];
+}
+
+export default function Seo({ pathname }) {
+  const metadata = getPageMetadata(pathname);
+  const canonicalUrl = `${SITE_URL}${metadata.path === "/" ? "/" : metadata.path}`;
+
+  return (
+    <Head>
+      <title>{metadata.title}</title>
+      <meta name="description" content={metadata.description} key="description" />
+      {metadata.noindex ? <meta name="robots" content="noindex, follow" key="robots" /> : null}
+      <link rel="canonical" href={canonicalUrl} key="canonical" />
+      <meta property="og:title" content={metadata.title} key="og-title" />
+      <meta property="og:description" content={metadata.description} key="og-description" />
+      <meta property="og:url" content={canonicalUrl} key="og-url" />
+      <meta property="og:site_name" content={SITE_NAME} key="og-site-name" />
+      <meta name="twitter:title" content={metadata.title} key="twitter-title" />
+      <meta name="twitter:description" content={metadata.description} key="twitter-description" />
+    </Head>
+  );
+}

--- a/components/__tests__/assetSource.test.js
+++ b/components/__tests__/assetSource.test.js
@@ -1,4 +1,4 @@
-import { resolveAssetSrc } from '../assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from '../assetSource';
 
 describe('resolveAssetSrc', () => {
   test('keeps string asset paths unchanged', () => {
@@ -11,5 +11,24 @@ describe('resolveAssetSrc', () => {
       width: 15,
       height: 10
     })).toBe('/_next/static/media/arrow.svg');
+  });
+});
+
+
+describe('asset dimensions', () => {
+  const image = {
+    src: '/_next/static/media/photo.jpg',
+    width: 1200,
+    height: 800
+  };
+
+  test('returns dimensions from Next static image objects', () => {
+    expect(resolveAssetWidth(image)).toBe(1200);
+    expect(resolveAssetHeight(image)).toBe(800);
+  });
+
+  test('omits dimensions for string assets', () => {
+    expect(resolveAssetWidth('/static/image.svg')).toBeUndefined();
+    expect(resolveAssetHeight('/static/image.svg')).toBeUndefined();
   });
 });

--- a/components/assetSource.js
+++ b/components/assetSource.js
@@ -9,3 +9,11 @@ export function resolveAssetSrc(asset) {
 
   return asset;
 }
+
+export function resolveAssetWidth(asset) {
+  return asset && typeof asset.width === 'number' ? asset.width : undefined;
+}
+
+export function resolveAssetHeight(asset) {
+  return asset && typeof asset.height === 'number' ? asset.height : undefined;
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,13 +1,49 @@
 import { useEffect } from "react";
+import { useRouter } from "next/router";
 import Fonts from "../components/Fonts";
+import Seo from "../components/Seo";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import "react-medium-image-zoom/dist/styles.css";
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
   useEffect(() => {
     Fonts();
   }, []);
-  return <Component {...pageProps} />;
+
+  return (
+    <>
+      <Seo pathname={router.pathname} />
+      <a className="skip-link" href="#main-content">
+        Skip to main content
+      </a>
+      <main id="main-content">
+        <Component {...pageProps} />
+      </main>
+      <style jsx global>{`
+        .skip-link {
+          background: var(--surface-elevated-color);
+          border: 2px solid var(--focus-outline);
+          border-radius: 999px;
+          color: var(--link-color);
+          left: 1rem;
+          padding: 0.65rem 1rem;
+          position: fixed;
+          top: 1rem;
+          transform: translateY(-200%);
+          transition: transform 0.2s ease;
+          z-index: 1000;
+        }
+
+        .skip-link:focus,
+        .skip-link:focus-visible {
+          outline: none;
+          transform: translateY(0);
+        }
+      `}</style>
+    </>
+  );
 }
 
 export default MyApp;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,11 +4,8 @@ import Fonts from "../components/Fonts";
 const v = process.env.NEXT_PUBLIC_BUILD_ID;
 
 const SITE_METADATA = Object.freeze({
-  title: "Harri Halonen",
-  description:
-    "Portfolio of Harri Halonen, a Finnish experience designer shaping research-led services and humane digital products from Tampere.",
-  siteUrl: "https://harritaito.com/",
   locale: "en_US",
+  siteName: "Harri Halonen",
   twitterHandle: "@harritaito",
   socialImage: {
     url: "https://harritaito.com/static/media/twittericon.png",
@@ -41,8 +38,7 @@ export default class MyDocument extends Document {
       }
     )();`;
 
-    const { title, description, siteUrl, locale, twitterHandle, socialImage } =
-      SITE_METADATA;
+    const { locale, siteName, twitterHandle, socialImage } = SITE_METADATA;
 
     return (
       <Html lang="en">
@@ -53,8 +49,6 @@ export default class MyDocument extends Document {
             name="viewport"
             content="width=device-width, initial-scale=1, viewport-fit=cover"
           />
-          <meta name="description" content={description} />
-          <link rel="canonical" href={siteUrl} />
           <link
             rel="icon"
             sizes="192x192"
@@ -67,16 +61,14 @@ export default class MyDocument extends Document {
             color="#49B882"
           />
           <link rel="icon" href={`/static/favicon.ico?v=${v}`} />
-          <meta property="og:url" content={siteUrl} />
+          <link rel="manifest" href="/manifest.webmanifest" />
+          <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
+          <meta name="theme-color" content="#0b1120" media="(prefers-color-scheme: dark)" />
           <meta property="og:type" content="website" />
-          <meta property="og:title" content={title} />
-          <meta property="og:site_name" content={title} />
-          <meta property="og:description" content={description} />
+          <meta property="og:site_name" content={siteName} />
           <meta property="og:locale" content={locale} />
           <meta name="twitter:site" content={twitterHandle} />
           <meta name="twitter:creator" content={twitterHandle} />
-          <meta name="twitter:title" content={title} />
-          <meta name="twitter:description" content={description} />
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:image" content={socialImage.url} />
           <meta name="twitter:image:alt" content={socialImage.alt} />

--- a/pages/about.js
+++ b/pages/about.js
@@ -5,7 +5,7 @@ import Navbar from "../components/Navbar";
 import HighlightUnderline from "../components/design-system/HighlightUnderline";
 import { colors, radii } from "../components/design-system/tokens";
 import mePhoto from "../static/media/about/me.jpg";
-import { resolveAssetSrc } from "../components/assetSource";
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from "../components/assetSource";
 
 class About extends Component {
   render() {
@@ -18,7 +18,13 @@ class About extends Component {
             content={
               <div className="my-photo-container col-xs-12 col-sm-12 col-md-12 col-lg-12 col-xl-12">
                 <div className={"my-photo"}>
-                  <img src={resolveAssetSrc(mePhoto)} alt={"Me"} />
+                  <img
+                    src={resolveAssetSrc(mePhoto)}
+                    alt="Harri Halonen"
+                    width={resolveAssetWidth(mePhoto)}
+                    height={resolveAssetHeight(mePhoto)}
+                    decoding="async"
+                  />
                 </div>
               </div>
             }

--- a/pages/aikakone.js
+++ b/pages/aikakone.js
@@ -5,7 +5,7 @@ import ProjectPage from "../components/ProjectPage";
 import Process from "../components/Process";
 import ProjectSection from "../components/ProjectSection";
 import Row from "../components/Row";
-import { resolveAssetSrc } from "../components/assetSource";
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from "../components/assetSource";
 import HighlightUnderline from "../components/design-system/HighlightUnderline";
 import { colors, shadows } from "../components/design-system/tokens";
 import { Carousel } from "react-responsive-carousel";
@@ -464,19 +464,19 @@ class Aikakone extends Component {
                           selectedItem={this.state.selectedSlideIndex}
                         >
                           <div>
-                            <img src={resolveAssetSrc(menu)} alt="Aikakone menu screen." />
+                            <img src={resolveAssetSrc(menu)} alt="Aikakone menu screen." width={resolveAssetWidth(menu)} height={resolveAssetHeight(menu)} decoding="async" />
                             <p className="legend">Aikakone menu screen.</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(aikakone)} alt="Aikakone session screen." />
+                            <img src={resolveAssetSrc(aikakone)} alt="Aikakone session screen." width={resolveAssetWidth(aikakone)} height={resolveAssetHeight(aikakone)} loading="lazy" decoding="async" />
                             <p className="legend">Aikakone session screen.</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(profile)} alt="Profile screen for a resident." />
+                            <img src={resolveAssetSrc(profile)} alt="Profile screen for a resident." width={resolveAssetWidth(profile)} height={resolveAssetHeight(profile)} loading="lazy" decoding="async" />
                             <p className="legend">Profile screen for a resident.</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(elamankaari)} alt="Elämänkaari life-story screen." />
+                            <img src={resolveAssetSrc(elamankaari)} alt="Elämänkaari life-story screen." width={resolveAssetWidth(elamankaari)} height={resolveAssetHeight(elamankaari)} loading="lazy" decoding="async" />
                             <p className="legend">Elämänkaari life-story screen.</p>
                           </div>
                         </Carousel>
@@ -498,6 +498,10 @@ class Aikakone extends Component {
                               className="mini-image"
                               src={resolveAssetSrc(view.image)}
                               alt={view.alt}
+                              width={resolveAssetWidth(view.image)}
+                              height={resolveAssetHeight(view.image)}
+                              loading="lazy"
+                              decoding="async"
                             />
                           </button>
                         );

--- a/pages/kivakaupunki.js
+++ b/pages/kivakaupunki.js
@@ -8,7 +8,7 @@ import ProjectPage from '../components/ProjectPage';
 import Process from '../components/Process';
 import ProjectSection from "../components/ProjectSection";
 import Row from '../components/Row';
-import { resolveAssetSrc } from '../components/assetSource';
+import { resolveAssetHeight, resolveAssetSrc, resolveAssetWidth } from '../components/assetSource';
 import HighlightUnderline from '../components/design-system/HighlightUnderline';
 import { colors, shadows } from '../components/design-system/tokens';
 import { Carousel } from 'react-responsive-carousel';
@@ -282,27 +282,27 @@ class Kivakaupunki extends Component {
                       <Modal isOpen={modalIsOpen} onRequestClose={this.toggleModal}>
                         <Carousel showThumbs={false} showStatus={false} selectedItem={this.state.selectedSlideIndex}>
                           <div>
-                            <img src={resolveAssetSrc(phone)} alt="Start greeting scene of app" />
+                            <img src={resolveAssetSrc(phone)} alt="Start greeting scene of app" width={resolveAssetWidth(phone)} height={resolveAssetHeight(phone)} decoding="async" />
                             <p className="legend">Start greeting scene of app</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(phone_booth)} alt="Location tagging by gps or by selecting and tapping." />
+                            <img src={resolveAssetSrc(phone_booth)} alt="Location tagging by gps or by selecting and tapping." width={resolveAssetWidth(phone_booth)} height={resolveAssetHeight(phone_booth)} loading="lazy" decoding="async" />
                             <p className="legend">Location tagging by gps or by selecting and tapping.</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(physical)} alt="Second screen, notice the return button" />
+                            <img src={resolveAssetSrc(physical)} alt="Second screen, notice the return button" width={resolveAssetWidth(physical)} height={resolveAssetHeight(physical)} loading="lazy" decoding="async" />
                             <p className="legend">Second screen, notice the return button</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(popup)} alt="Comment categories" />
+                            <img src={resolveAssetSrc(popup)} alt="Comment categories" width={resolveAssetWidth(popup)} height={resolveAssetHeight(popup)} loading="lazy" decoding="async" />
                             <p className="legend">Comment categories</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(watch)} alt="Comment input" />
+                            <img src={resolveAssetSrc(watch)} alt="Comment input" width={resolveAssetWidth(watch)} height={resolveAssetHeight(watch)} loading="lazy" decoding="async" />
                             <p className="legend">Comment input</p>
                           </div>
                           <div>
-                            <img src={resolveAssetSrc(footsteps)} alt="Final thank you screen" />
+                            <img src={resolveAssetSrc(footsteps)} alt="Final thank you screen" width={resolveAssetWidth(footsteps)} height={resolveAssetHeight(footsteps)} loading="lazy" decoding="async" />
                             <p className="legend">Final thank you screen</p>
                           </div>
                         </Carousel>
@@ -312,7 +312,7 @@ class Kivakaupunki extends Component {
                     <Row className="one-margin-top" content={views.map(function (image, index) {
                         return (
                           <div key={"sketch" + index} onClick={(e) => self.toggleModal(index, e)} className={"col-xs-4 col-sm-4 col-md-2 col-lg-2 col-xl-2"}>
-                            <img className="mini-image" src={resolveAssetSrc(image)} alt=""/>
+                            <img className="mini-image" src={resolveAssetSrc(image)} alt="" width={resolveAssetWidth(image)} height={resolveAssetHeight(image)} loading="lazy" decoding="async" />
                           </div>
                         )
                       })

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "Harri Halonen",
+  "short_name": "Harri",
+  "description": "Portfolio of Harri Halonen, a Finnish experience designer shaping research-led services and humane digital products.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "minimal-ui",
+  "background_color": "#fafafa",
+  "theme_color": "#49B882",
+  "icons": [
+    {
+      "src": "/static/media/touch-icon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/media/touch-icon.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://harritaito.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://harritaito.com/</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/about</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/projects</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/contact</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/thesis</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/hri-study</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/kivakaupunki</loc>
+  </url>
+  <url>
+    <loc>https://harritaito.com/aikakone</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
### Motivation
- Improve SEO and social metadata handling site-wide and provide canonical and structured metadata for key routes. 
- Improve performance and layout stability by surfacing image dimensions and enabling lazy loading/async decoding for images. 
- Improve accessibility and progressive enhancement with a skip link and more semantic header/nav markup. 
- Add PWA/web discovery files (`manifest`, `robots.txt`, `sitemap.xml`) for crawlers and installability.

### Description
- Added a new `Seo` component (`components/Seo.js`) and integrated it into `pages/_app.js` to inject page metadata based on route via `getPageMetadata`.
- Exposed image dimension helpers in `components/assetSource.js` by adding `resolveAssetWidth` and `resolveAssetHeight` and updated usages across components to set `width`, `height`, `loading="lazy"` (where appropriate) and `decoding="async"` on `<img>` elements in `Callout`, `Lightbox`, `Process`, `Project`, `ProjectIcon`, `ProjectPage`, `About`, `Aikakone`, and `Kivakaupunki`.
- Made the top-level navigation more semantic by switching `.nav` wrapper from `div` to `header`, and the inner container from `div` to `nav` with `aria-label` for primary navigation, and added a keyboard-accessible skip link in `pages/_app.js` that wraps the app content in a `main` with `id="main-content"`.
- Updated `pages/_document.js` to simplify and correct Open Graph and theme metadata, add `manifest` link and `theme-color` tags, and keep initial theme setup script.
- Added static site assets: `public/manifest.webmanifest`, `public/robots.txt`, and `public/sitemap.xml`.
- Updated `components/__tests__/assetSource.test.js` to cover the new width/height helpers and ensure behavior for string vs Next image objects.

### Testing
- Ran unit tests with `jest` including the updated `components/__tests__/assetSource.test.js`, and all tests passed.
- Verified that the updated image helper tests asserting `resolveAssetWidth` and `resolveAssetHeight` behaviors succeeded. 
- No automated end-to-end tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288b8d4c748330b78a3ff775215a35)