### PR TITLE
fix: add mobile project content gutters

### DIFF
--- a/components/ProjectPage.js
+++ b/components/ProjectPage.js
@@ -114,6 +114,13 @@ class ProjectPage extends Component {
             padding: 3em 0 1em;
           }
 
+          @media only screen and (max-width: 45rem) {
+            .project-page .content {
+              padding-left: 0.75rem;
+              padding-right: 0.75rem;
+            }
+          }
+
           .project-page h1 {
             margin: 0 auto;
           }


### PR DESCRIPTION
### Motivation
- Project case-study content on narrow viewports sat flush to the left and right edges, harming readability; mobile horizontal gutters are needed.

### Description
- Added a mobile-only CSS rule in `components/ProjectPage.js` to apply `padding-left: 0.75rem` and `padding-right: 0.75rem` to `.project-page .content` under `@media only screen and (max-width: 45rem)`, keeping the change scoped to the shared project page wrapper, and `npm run build` refreshed generated `out/` files which were left unstaged per repo policy.

### Testing
- Ran `npm test` (Jest) which passed, and `npm run build` (Next.js build + export) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e49a53c04833085c6355ee2523838)