### PR TITLE
Add writing article styles, light shadow token, and writing-plan doc

### DIFF
--- a/components/__tests__/WritingArticle.test.js
+++ b/components/__tests__/WritingArticle.test.js
@@ -1,0 +1,13 @@
+import { estimateReadingTime } from "../../lib/readingTime";
+
+describe("writing article helpers", () => {
+  test("estimates at least one minute for short articles", () => {
+    expect(estimateReadingTime("A short note.")).toBe("1 min read");
+  });
+
+  test("rounds article reading time up", () => {
+    const words = Array.from({ length: 221 }, (_, index) => `word${index}`).join(" ");
+
+    expect(estimateReadingTime(words)).toBe("2 min read");
+  });
+});

--- a/components/design-system/tokens.js
+++ b/components/design-system/tokens.js
@@ -23,6 +23,7 @@ export const shadows = {
   mediaHover: "0 0.75em 1.25em 0 rgba(0,0,0,0.30)",
   card: "0 1em 2em 0 rgba(0,0,0,0.30)",
   cardHover: "0 1.5em 2.5em 0 rgba(0,0,0,0.30)",
+  light: "0 0.25em 0.5em 0 rgba(0,0,0,0.15)",
   nav: "0 .2em .2em 0 rgba(0,0,0,0.10)",
 };
 

--- a/docs/reading-experience-optimization-plan.md
+++ b/docs/reading-experience-optimization-plan.md
@@ -1,0 +1,194 @@
+# Reading experience optimization plan
+
+## Research summary
+
+This plan focuses on Markdown-backed article pages in `/writing/[slug]`. It is based on
+research from Nielsen Norman Group, Baymard, W3C WCAG text-spacing guidance, MDN CSS
+text-wrap documentation, and current examples of comfortable online article reading.
+
+The strongest cross-source themes are:
+
+- Reading is not only typography. It is legibility, scanability, comprehension, and a clear
+  reason to keep going.
+- Body copy should usually sit around 50 to 75 characters per line on desktop, with mobile
+  layouts allowed to fill more of the screen.
+- Line-height must stay generous, and the layout should not break if users override text
+  spacing for accessibility.
+- Headings, summaries, dates, tags, and in-page signposts make long writing easier to scan
+  before committing to a full read.
+- `text-wrap: balance` is useful for headings; `text-wrap: pretty` can be used as progressive
+  enhancement for paragraphs, but should stay limited to article copy because it has a
+  performance cost.
+- Reading pages should provide exits and continuation paths: back to index, permalink,
+  related writing, contact, or project pages.
+
+## Current-state diagnosis
+
+The current writing template has started moving in the right direction with article metadata,
+reading time, tags, styled Markdown, and a footer. The next optimization pass should make the
+experience more deliberate and measurable instead of only more styled.
+
+Priority issues to solve next:
+
+1. The article shell still borrows `ProjectPage`, so article-specific semantics and layout control
+   are limited.
+2. There is no table of contents or heading anchor pattern for longer Markdown pieces.
+3. Metadata is present, but the writing index does not yet expose the same reading-time and tag
+   cues.
+4. Markdown components do not yet support code blocks, captions, footnotes, or callouts as a
+   designed reading system.
+5. Related posts are planned but not implemented, so the article footer is still generic.
+6. Accessibility checks are indirect. There is no specific test for text-spacing resilience,
+   heading structure, or keyboard-visible article navigation.
+
+## Optimization principles
+
+### 1. Keep the reading measure stable
+
+Use character-based widths rather than only grid columns. The target should be:
+
+- body paragraphs: `max-width: 66ch`;
+- metadata and footer cards: `max-width: 72ch`;
+- images, tables, and rich media: allowed to break wider when they benefit from scale.
+
+This should make the article body responsive without relying on arbitrary pixel widths.
+
+### 2. Separate article structure from project structure
+
+Create a dedicated `ArticlePage` component once one more article-specific feature is added.
+It should own:
+
+- article masthead;
+- metadata rail or card;
+- hero image and credit;
+- Markdown body container;
+- article footer;
+- optional related writing.
+
+`ProjectPage` should remain the case-study layout. This avoids article styling becoming a large
+set of overrides against project-specific markup.
+
+### 3. Make scanning intentional
+
+For long Markdown pages, add:
+
+- heading anchors for `h2` and `h3`;
+- an optional compact table of contents generated from Markdown headings;
+- section spacing that increases before major headings and tightens within subsections;
+- short metadata labels that reinforce date, time, topic, and update status.
+
+The table of contents should be hidden or collapsible on small screens.
+
+### 4. Make Markdown components feel authored
+
+Extend `ArticleBody` with designed renderers for:
+
+- `code` and `pre` blocks;
+- `figure`-like image captions via Markdown convention;
+- footnotes from `remark-gfm`;
+- horizontal rules as quiet section breaks;
+- callouts only if they appear in at least three pieces.
+
+Avoid decorative components until the content asks for them.
+
+### 5. Improve continuity after reading
+
+Replace the generic footer copy with data-backed links:
+
+- related articles from frontmatter `related` slugs;
+- fallback to latest public writing;
+- one contact link for readers who want to discuss the idea;
+- canonical permalink only when it differs from the local path or is useful for sharing.
+
+Do not add comments, reactions, or webmentions until moderation and privacy are clear.
+
+### 6. Verify accessibility directly
+
+Add checks for:
+
+- reading-time helper behavior;
+- public articles excluding protected articles in any related-writing fallback;
+- article pages rendering one `h1`;
+- focusable back/permalink/related links;
+- no layout loss when text spacing is increased according to WCAG 1.4.12.
+
+Visual checks should include desktop, tablet, and mobile widths.
+
+## Proposed implementation phases
+
+### Phase 1: Measurement and metadata alignment
+
+- Move body width to a `ch`-based article reading token or local constant.
+- Use the same reading-time and tag data on `/writing` cards and `/writing/[slug]`.
+- Add `updated`, `heroCredit`, and `related` to documented frontmatter examples.
+- Keep the current article page component structure for this phase.
+
+Success criteria:
+
+- Public writing cards show title, summary, date, reading time, and tags when present.
+- Article body paragraphs stay near 50 to 75 characters on common desktop widths.
+- Existing articles without new fields still build.
+
+### Phase 2: Dedicated article component
+
+- Extract article layout from `pages/writing/[slug].js` into `components/ArticlePage.js`.
+- Keep data fetching in the page route.
+- Move article-specific CSS into the component and reduce global overrides.
+- Keep `ArticleBody` focused on Markdown rendering.
+
+Success criteria:
+
+- `ProjectPage` is no longer used for writing articles.
+- The article page has semantic `article`, `header`, `main`, and `footer` regions.
+- Tests cover the article page shell without importing ESM-only Markdown dependencies directly.
+
+### Phase 3: Markdown reading toolkit
+
+- Add heading IDs and anchor links for `h2` and `h3`.
+- Add optional table of contents generation from Markdown headings.
+- Style code blocks, tables, blockquotes, images, and footnotes as a coherent article system.
+- Add a wider media breakout class or Markdown convention for images that need scale.
+
+Success criteria:
+
+- Long articles are scannable from the top.
+- Code and tables are readable without horizontal page overflow.
+- Footnotes and captions are visually quiet but discoverable.
+
+### Phase 4: Continuation paths
+
+- Resolve `related` slugs in `getStaticProps`.
+- Render related writing cards in the article footer.
+- Fallback to latest public articles when no related slugs are provided.
+- Keep protected articles out of related lists and RSS/feed candidates.
+
+Success criteria:
+
+- Every article has a meaningful next step.
+- Protected articles are never exposed through related-writing fallback.
+- Footer copy becomes content-aware instead of generic.
+
+### Phase 5: Comfort and preference polish
+
+- Audit contrast and text spacing with browser zoom and custom spacing styles.
+- Consider a reading-width preference only if articles become long enough to justify it.
+- Add print styles for essay pages.
+- Add RSS and canonical metadata after public writing volume justifies it.
+
+Success criteria:
+
+- Articles remain usable at 200% zoom.
+- Custom text spacing does not clip, overlap, or hide content.
+- Print output is readable without navigation clutter.
+
+## Recommended next slice
+
+Implement Phase 1 only:
+
+1. Add a `readingMeasure` constant or token using `66ch`.
+2. Apply it to article body copy, metadata, and footer in JSX CSS.
+3. Surface reading time and tags on `/writing` article cards.
+4. Add one test for writing index metadata rendering.
+5. Leave table of contents, related posts, and `ArticlePage` extraction for follow-up work.
+
+This gives the site a better reading experience quickly while avoiding another broad rewrite.

--- a/docs/writing-pages-indieweb-plan.md
+++ b/docs/writing-pages-indieweb-plan.md
@@ -1,0 +1,148 @@
+# Writing pages IndieWeb plan
+
+## Source reference
+
+The reference article is Brennan Kenneth Brown's user-provided folk.zone announcement.
+I am treating it as an inspiration source, not a visual clone. The useful patterns are:
+
+- a plain, durable article shell with skip navigation and readable no-JavaScript fallback;
+- rich article metadata: author, publish date, reading time, tags, canonical permalink;
+- a large, credited hero image with descriptive alt text;
+- short, lowercase section headings that make the essay easy to scan;
+- post-body affordances: reaction, author bio, RSS/newsletter prompt, comments, webmentions,
+  related posts, blogroll, badges, and webrings;
+- IndieWeb identity signals: RSS, IndieAuth-style commenting, webmentions, canonical URL,
+  visible source/build information, and personal network links.
+
+## Fit for this portfolio
+
+Harri's portfolio should not become a dense personal blog sidebar. The writing pages should borrow
+Brennan's sense of independent web ownership while preserving the current design direction: light
+paper background, Trirong and Rubik typography, selective accents, soft tactile elevation, and
+restrained motion.
+
+The right translation is a quiet writing system for essays, research notes, and process pieces that
+helps a hiring manager or collaborator understand Harri's thinking without leaving the portfolio
+context.
+
+## Implementation goals
+
+1. Make `/writing` feel like an authored publication index, not a placeholder list.
+2. Make `/writing/[slug]` support long-form essays with metadata, tags, credits, and related links.
+3. Add IndieWeb-compatible hooks gradually, starting with static, low-maintenance features.
+4. Keep generated deployment output out of implementation commits.
+
+## Phase 1: Article data model
+
+Add optional frontmatter fields to public and protected Markdown articles:
+
+- `title`: existing page title.
+- `summary`: existing description and article-card excerpt.
+- `date`: existing publish date.
+- `updated`: optional material update date.
+- `eyebrow`: existing article category label.
+- `tags`: array of topic tags.
+- `hero`: existing hero path.
+- `heroAlt`: required when `hero` is meaningful.
+- `heroCredit`: optional short credit line.
+- `canonicalUrl`: optional final public permalink.
+- `readingTime`: optional override; otherwise calculate from Markdown word count.
+- `related`: optional array of related article slugs.
+
+Verification:
+
+- Add tests for article sorting, protected filtering, and reading-time fallback.
+- Confirm articles without new fields still build.
+
+## Phase 2: Writing index upgrades
+
+Upgrade `/writing` with source-friendly publication cues:
+
+- Add a warmer intro that explains what the writing section is for.
+- Show count, latest month, and topic filters when tags exist.
+- Render article cards with date, reading time, summary, and tags.
+- Preserve the current highlight underline, paper background, and narrow readable measure.
+- Add an RSS link only if an RSS feed exists or is implemented in the same phase.
+
+Verification:
+
+- Run the existing writing index tests or add snapshot-free rendering tests if none exist.
+- Check empty state still reads well when there are no public articles.
+
+## Phase 3: Article template upgrades
+
+Evolve `/writing/[slug]` from a case-study shell into a dedicated essay shell:
+
+- Keep the existing portfolio navbar and footer for continuity.
+- Add a compact article masthead: category, title, summary, date, reading time, and tags.
+- Place a credited hero image below the masthead when present.
+- Keep article body width around 60 to 70 characters for comfortable reading.
+- Add section heading styles that feel editorial but still use the existing typography tokens.
+- Add a post footer with permalink, tags, author note, and related articles.
+- Include a "back to writing" path so articles are not dead ends.
+
+Verification:
+
+- Test Markdown rendering for headings, lists, blockquotes, images, tables, and links.
+- Verify keyboard focus states on article links and the back link.
+
+## Phase 4: IndieWeb basics
+
+Start with static primitives that do not require a server:
+
+- Generate canonical URLs for articles.
+- Add RSS feed generation for public, non-draft articles.
+- Add `rel="me"` profile links where appropriate.
+- Use semantic `article`, `header`, `footer`, and `time` markup.
+- Add microformat-friendly classes only where they do not fight the component structure.
+
+Verification:
+
+- Validate generated RSS XML in a test.
+- Confirm protected articles do not appear in RSS, index pages, or related-post lists.
+
+## Phase 5: Community affordances
+
+Add interactive or networked features only after the static writing system works:
+
+- Webmention display can start as a static placeholder or build-time fetch.
+- Commenting should be deferred unless there is a clear moderation and privacy plan.
+- Reactions should be avoided unless they are backed by a low-maintenance service.
+- A blogroll or "read nearby" section could be added as a curated static list.
+
+Verification:
+
+- Ensure failures in external webmention or feed fetching never break the build.
+- Keep all third-party scripts optional and privacy-conscious.
+
+## Visual translation notes
+
+Use Brennan's page as a structural reference, but translate it into Harri's system:
+
+- Replace Brennan's maximal side matter with one calm post-footer stack.
+- Keep badges and webrings optional; if added, make them feel like small desk ephemera rather
+  than a retro wall of buttons.
+- Use project accent colors for tags sparingly, not as full-page decoration.
+- Prefer soft paper cards and marker highlights over dark terminal or zine aesthetics.
+- Keep motion limited to hover lift, underline motion, and gentle transitions.
+
+## Risks and decisions to make
+
+- Decide whether writing should be public-only or include protected essays in the same template.
+- Decide whether RSS should ship before there are several public articles.
+- Decide whether IndieWeb comments fit the portfolio's hiring/client audience.
+- Decide whether article pages should continue using `ProjectPage` or move to a dedicated
+  `ArticlePage` component to reduce case-study assumptions.
+
+## Recommended first implementation slice
+
+Build the smallest complete slice first:
+
+1. Add reading-time calculation and tags to article metadata.
+2. Upgrade `/writing` cards to show metadata.
+3. Create a dedicated article masthead in `/writing/[slug]` while keeping `ArticleBody` intact.
+4. Add a static post footer with permalink and back-to-writing link.
+5. Add tests for metadata and protected-article exclusion.
+
+This gives the writing area the authored, IndieWeb-adjacent feel without committing to comments,
+webmentions, feeds, or community widgets before the content model proves itself.

--- a/lib/readingTime.js
+++ b/lib/readingTime.js
@@ -1,0 +1,4 @@
+export function estimateReadingTime(content) {
+  const words = String(content || "").trim().split(/\s+/).filter(Boolean).length;
+  return `${Math.max(1, Math.ceil(words / 220))} min read`;
+}

--- a/pages/writing/[slug].js
+++ b/pages/writing/[slug].js
@@ -1,13 +1,93 @@
 import React from "react";
+import Link from "next/link";
 
 import ProjectPage from "../../components/ProjectPage";
 import ArticleBody from "../../components/ArticleBody";
-import { colors, shadows } from "../../components/design-system/tokens";
+import { colors, radii, shadows } from "../../components/design-system/tokens";
 import { getArticleSlugs, getArticleBySlug } from "../../lib/articles";
+import { estimateReadingTime } from "../../lib/readingTime";
 
 const placeholderHero = "/static/media/pohja.svg";
+const pStyle =
+  "col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6";
 
-const Article = ({ frontmatter, content }) => (
+function formatDate(value) {
+  if (!value) return "Undated";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return date.toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function normalizeTags(tags) {
+  if (!Array.isArray(tags)) return [];
+  return tags.filter(Boolean);
+}
+
+const ArticleMeta = ({ frontmatter, readingTime }) => {
+  const tags = normalizeTags(frontmatter.tags);
+
+  return (
+    <section className={`${pStyle} article-meta`} aria-label="Article details">
+      <dl className="article-meta-list">
+        <div>
+          <dt>Published</dt>
+          <dd>
+            <time dateTime={frontmatter.date || undefined}>{formatDate(frontmatter.date)}</time>
+          </dd>
+        </div>
+        <div>
+          <dt>Reading time</dt>
+          <dd>{frontmatter.readingTime || readingTime}</dd>
+        </div>
+        {frontmatter.updated ? (
+          <div>
+            <dt>Updated</dt>
+            <dd>
+              <time dateTime={frontmatter.updated}>{formatDate(frontmatter.updated)}</time>
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+      {tags.length ? (
+        <ul className="article-tags" aria-label="Topics">
+          {tags.map((tag) => (
+            <li key={tag}>{tag}</li>
+          ))}
+        </ul>
+      ) : null}
+      {frontmatter.heroCredit ? (
+        <p className="hero-credit">Image: {frontmatter.heroCredit}</p>
+      ) : null}
+    </section>
+  );
+};
+
+const ArticleFooter = ({ frontmatter, slug }) => {
+  const permalink = frontmatter.canonicalUrl || `/writing/${slug}`;
+
+  return (
+    <footer className={`${pStyle} article-footer`}>
+      <p className="footer-kicker">Keep reading</p>
+      <h2>More notes from the worktable</h2>
+      <p>
+        This piece is part of a small writing shelf for process notes, research reflections,
+        and design decisions that do not need a full case study.
+      </p>
+      <div className="article-footer-actions">
+        <Link href="/writing" legacyBehavior>
+          <a>Back to writing</a>
+        </Link>
+        <a href={permalink}>Permalink</a>
+      </div>
+    </footer>
+  );
+};
+
+const Article = ({ frontmatter, content, readingTime, slug }) => (
   <div className="Article">
     <ProjectPage
       projectName={frontmatter.title}
@@ -16,14 +96,21 @@ const Article = ({ frontmatter, content }) => (
       hero={frontmatter.hero || placeholderHero}
       heroAlt={frontmatter.heroAlt || ""}
       eyebrow={frontmatter.eyebrow || "Writing"}
-      navbarColor={frontmatter.navbarColor || ""}
+      navbarColor={frontmatter.navbarColor || "green"}
       showNextProject={false}
-      content={<ArticleBody content={content} />}
+      content={
+        <>
+          <ArticleMeta frontmatter={frontmatter} readingTime={readingTime} />
+          <ArticleBody content={content} />
+          <ArticleFooter frontmatter={frontmatter} slug={slug} />
+        </>
+      }
     />
     <style jsx global>{`
       .Article .project-page {
         background:
           radial-gradient(circle at 12% 8%, rgba(139, 200, 246, 0.22), transparent 17rem),
+          linear-gradient(180deg, rgba(255, 255, 255, 0.64), transparent 24rem),
           ${colors.pageBackground};
         padding-top: 5rem;
       }
@@ -61,7 +148,61 @@ const Article = ({ frontmatter, content }) => (
       }
 
       .Article .project-page .content {
-        margin-top: 3.5rem;
+        margin-top: 0;
+      }
+
+      .Article .article-meta {
+        background: rgba(255, 255, 255, 0.82);
+        box-shadow: ${shadows.light};
+        margin: -2rem auto 3.5rem;
+        padding: 1.15rem 1.25rem;
+        position: relative;
+        z-index: 1;
+      }
+
+      .Article .article-meta-list {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        margin: 0;
+      }
+
+      .Article .article-meta-list dt,
+      .Article .footer-kicker,
+      .Article .hero-credit {
+        color: ${colors.textMuted};
+        font-size: 0.78rem;
+        font-weight: 500;
+        letter-spacing: 0.08em;
+        margin: 0;
+        text-transform: uppercase;
+      }
+
+      .Article .article-meta-list dd {
+        color: ${colors.textStrong};
+        font-size: 0.98rem;
+        margin: 0.2rem 0 0;
+      }
+
+      .Article .article-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        list-style: none;
+        margin: 1rem 0 0;
+        padding: 0;
+      }
+
+      .Article .article-tags li {
+        border: 1px solid rgba(18, 164, 45, 0.24);
+        border-radius: ${radii.pill};
+        color: ${colors.accentGreen};
+        font-size: 0.85rem;
+        padding: 0.25rem 0.7rem;
+      }
+
+      .Article .hero-credit {
+        margin-top: 1rem;
       }
 
       .Article .ArticleBody p,
@@ -123,6 +264,46 @@ const Article = ({ frontmatter, content }) => (
         margin: 1rem auto 2rem;
       }
 
+      .Article .article-footer {
+        border-top: 1px solid rgba(105, 106, 109, 0.22);
+        margin: 4rem auto 2rem;
+        padding-top: 1.5rem;
+      }
+
+      .Article .article-footer h2 {
+        font-size: clamp(1.75rem, 4vw, 2.6rem);
+        line-height: 1.1;
+        margin: 0.35rem 0 0.75rem;
+      }
+
+      .Article .article-footer p {
+        color: ${colors.textMuted};
+        line-height: 1.7;
+        max-width: 38rem;
+      }
+
+      .Article .article-footer-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 1.25rem;
+      }
+
+      .Article .article-footer-actions a {
+        border: 1px solid ${colors.accentGreen};
+        border-radius: ${radii.pill};
+        color: ${colors.accentGreen};
+        padding: 0.45rem 1rem;
+        text-decoration: none;
+        transition: all 0.2s linear;
+      }
+
+      .Article .article-footer-actions a:hover,
+      .Article .article-footer-actions a:focus {
+        background: ${colors.accentGreen};
+        color: white;
+      }
+
       @media only screen and (max-width: 45rem) {
         .Article .project-page {
           padding-top: 3.5rem;
@@ -132,8 +313,12 @@ const Article = ({ frontmatter, content }) => (
           font-size: clamp(2.4rem, 14vw, 4rem);
         }
 
-        .Article .project-page .content {
-          margin-top: 2rem;
+        .Article .article-meta {
+          margin-top: -1rem;
+        }
+
+        .Article .article-meta-list {
+          grid-template-columns: 1fr;
         }
       }
     `}</style>
@@ -149,7 +334,14 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const { frontmatter, content } = getArticleBySlug(params.slug);
-  return { props: { frontmatter, content } };
+  return {
+    props: {
+      frontmatter,
+      content,
+      readingTime: estimateReadingTime(content),
+      slug: params.slug,
+    },
+  };
 }
 
 export default Article;

--- a/pages/writing/[slug].js
+++ b/pages/writing/[slug].js
@@ -2,6 +2,7 @@ import React from "react";
 
 import ProjectPage from "../../components/ProjectPage";
 import ArticleBody from "../../components/ArticleBody";
+import { colors, shadows } from "../../components/design-system/tokens";
 import { getArticleSlugs, getArticleBySlug } from "../../lib/articles";
 
 const placeholderHero = "/static/media/pohja.svg";
@@ -19,6 +20,123 @@ const Article = ({ frontmatter, content }) => (
       showNextProject={false}
       content={<ArticleBody content={content} />}
     />
+    <style jsx global>{`
+      .Article .project-page {
+        background:
+          radial-gradient(circle at 12% 8%, rgba(139, 200, 246, 0.22), transparent 17rem),
+          ${colors.pageBackground};
+        padding-top: 5rem;
+      }
+
+      .Article .project-page h1 {
+        font-family: Trirong, serif;
+        font-size: clamp(3rem, 8vw, 6.5rem);
+        font-weight: 500;
+        letter-spacing: 0.02em;
+        line-height: 0.95;
+        text-wrap: balance;
+      }
+
+      .Article .project-eyebrow {
+        color: ${colors.accentGreen};
+        letter-spacing: 0.12em;
+      }
+
+      .Article .project-page .subtitle {
+        font-size: clamp(1.25rem, 2.8vw, 2.25rem);
+      }
+
+      .Article .project-page .subtitle p {
+        color: ${colors.textMuted};
+        line-height: 1.35;
+        max-width: 36rem;
+        text-wrap: pretty;
+      }
+
+      .Article .hero-image {
+        background: white;
+        border-radius: 0 0 2.5rem 0;
+        max-height: 28rem;
+        object-position: center;
+      }
+
+      .Article .project-page .content {
+        margin-top: 3.5rem;
+      }
+
+      .Article .ArticleBody p,
+      .Article .ArticleBody .list,
+      .Article .ArticleBody .blockquote,
+      .Article .ArticleBody .table-wrap {
+        font-size: 1.06rem;
+        max-width: 42rem;
+      }
+
+      .Article .ArticleBody p {
+        color: ${colors.textStrong};
+        line-height: 1.85;
+        text-wrap: pretty;
+      }
+
+      .Article .ArticleBody h2 {
+        border-top: 1px solid rgba(105, 106, 109, 0.22);
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        line-height: 1.08;
+        margin-top: 4rem;
+        padding-top: 1.25rem;
+        text-wrap: balance;
+      }
+
+      .Article .ArticleBody h3,
+      .Article .ArticleBody h4 {
+        color: ${colors.textStrong};
+        letter-spacing: -0.01em;
+        margin-top: 2.25rem;
+        text-wrap: balance;
+      }
+
+      .Article .ArticleBody a {
+        background-image: linear-gradient(
+          transparent 58%,
+          ${colors.markerHighlight} 58%,
+          ${colors.markerHighlight} 88%,
+          transparent 88%
+        );
+        color: ${colors.textStrong};
+        text-decoration: none;
+      }
+
+      .Article .ArticleBody a:hover,
+      .Article .ArticleBody a:focus {
+        color: ${colors.accentGreen};
+      }
+
+      .Article .ArticleBody .blockquote {
+        background: rgba(255, 255, 255, 0.68);
+        box-shadow: ${shadows.light};
+        padding: 1rem 1.25rem;
+      }
+
+      .Article .ArticleBody .article-image {
+        border-radius: 0 1.5rem 0 0;
+        box-shadow: ${shadows.media};
+        margin: 1rem auto 2rem;
+      }
+
+      @media only screen and (max-width: 45rem) {
+        .Article .project-page {
+          padding-top: 3.5rem;
+        }
+
+        .Article .project-page h1 {
+          font-size: clamp(2.4rem, 14vw, 4rem);
+        }
+
+        .Article .project-page .content {
+          margin-top: 2rem;
+        }
+      }
+    `}</style>
   </div>
 );
 


### PR DESCRIPTION
### Motivation

- Introduce a dedicated visual treatment for long-form `writing` pages and capture a plan for evolving the writing area toward IndieWeb-friendly features. 
- Provide a small token addition to support a softer shadow used by article elements.

### Description

- Added a planning document at `docs/writing-pages-indieweb-plan.md` outlining the article data model, phased implementation, and verification steps for the writing section. 
- Updated `components/design-system/tokens.js` to add a new `shadows.light` token (`0 0.25em 0.5em 0 rgba(0,0,0,0.15)`).
- Enhanced the article page at `pages/writing/[slug].js` to import design tokens and inject global JSX styles that implement the article masthead, hero image, typography, responsive headings, readable content measure, link highlight, blockquote/card treatments, and image styling while preserving existing data fetching via `getStaticPaths` and `getStaticProps`.

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3302bafc4483308fb4fc3a85be5615)