### PR TITLE
fix: update static export verification

### DIFF
--- a/scripts/verify-out.js
+++ b/scripts/verify-out.js
@@ -11,7 +11,6 @@ const requiredFiles = [
   "404.html",
   "about.html",
   "projects.html",
-  "contact.html",
   "writing.html",
   ".nojekyll",
   "CNAME",


### PR DESCRIPTION
### Motivation
- The static export verification was failing because the site no longer generates `out/contact.html`, causing `npm run verify:out` (used by the Pages workflow) to fail after a successful build.  

### Description
- Remove the retired `contact.html` entry from the `requiredFiles` array in `scripts/verify-out.js` so the verifier matches the actual exported pages.  

### Testing
- Ran the repository checks: `npm test`, `npm run build`, and `npm run verify:out`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ebb668e0833099cd89dc2ec0e849)