### PR TITLE
style: apply Prettier formatting to UI components and pages

### DIFF
--- a/components/SpecSheet.js
+++ b/components/SpecSheet.js
@@ -56,9 +56,9 @@ const SpecSheet = () => (
       <p className="spec-sheet__kicker">Design spec · one component, in full</p>
       <h4 className="spec-sheet__title">Filter field + results list</h4>
       <p className="spec-sheet__note">
-        Illustrative example — the structure is how I actually spec, the project is not real.
-        Where a design system exists, each rule below points at named tokens and components
-        instead of raw values.
+        Illustrative example — the structure is how I actually spec, the project is not real. Where
+        a design system exists, each rule below points at named tokens and components instead of raw
+        values.
       </p>
     </header>
 

--- a/components/WritingCloudBackground.js
+++ b/components/WritingCloudBackground.js
@@ -61,16 +61,17 @@ export function createCloudShape(random, width, height, depth = 1) {
       height * range(random, 0.55, 0.74),
     ],
     () => [width * range(random, 0.07, 0.13), height * range(random, 0.13, 0.23)],
-    [10, 15]
+    [10, 15],
   );
   addPuffs(
     Math.floor(range(random, 9, 14)),
     (progress) => [
       width * (0.12 + progress * 0.76) + range(random, -width * 0.045, width * 0.045),
-      height * range(random, 0.24, 0.5) - Math.sin(progress * Math.PI) * height * range(random, 0.08, 0.2),
+      height * range(random, 0.24, 0.5) -
+        Math.sin(progress * Math.PI) * height * range(random, 0.08, 0.2),
     ],
     () => [width * range(random, 0.06, 0.13), height * range(random, 0.12, 0.22)],
-    [10, 16]
+    [10, 16],
   );
   addPuffs(
     Math.floor(range(random, 8, 12)),
@@ -79,7 +80,7 @@ export function createCloudShape(random, width, height, depth = 1) {
       height * range(random, 0.12, 0.3),
     ],
     () => [width * range(random, 0.06, 0.14), height * range(random, 0.07, 0.14)],
-    [9, 14]
+    [9, 14],
   );
 
   const facetCount = Math.round(range(random, 22, 38) * depth);
@@ -87,7 +88,14 @@ export function createCloudShape(random, width, height, depth = 1) {
     const cx = range(random, -width * 0.04, width * 1.04);
     const cy = range(random, height * 0.08, height * 0.9);
     facets.push({
-      points: polygon(random, cx, cy, width * range(random, 0.018, 0.055), height * range(random, 0.025, 0.08), random() > 0.82 ? 4 : 3),
+      points: polygon(
+        random,
+        cx,
+        cy,
+        width * range(random, 0.018, 0.055),
+        height * range(random, 0.025, 0.08),
+        random() > 0.82 ? 4 : 3,
+      ),
       shade: cy / height,
       cool: cy > height * range(random, 0.52, 0.72),
       hueOffset: range(random, -7, 8),
@@ -141,7 +149,12 @@ function drawCloud(ctx, cloud, x, y, opacity) {
   veil.addColorStop(0, "rgba(255, 255, 251, 0.14)");
   veil.addColorStop(1, "rgba(246, 232, 208, 0.04)");
   ctx.fillStyle = veil;
-  ctx.fillRect(x - cloud.width * 0.08, y - cloud.height * 0.08, cloud.width * 1.16, cloud.height * 1.16);
+  ctx.fillRect(
+    x - cloud.width * 0.08,
+    y - cloud.height * 0.08,
+    cloud.width * 1.16,
+    cloud.height * 1.16,
+  );
   ctx.restore();
 }
 
@@ -155,27 +168,37 @@ function createClouds(width, height, seed) {
 
   return layers
     .flatMap((layer, layerIndex) =>
-      Array.from({ length: Math.ceil(width / (620 - layerIndex * 70)) + layer.count }, (_, index) => {
-        const cloudWidth = Math.min(width * 1.08 + 180, Math.max(260, width * range(random, ...layer.width)));
-        const cloudHeight = cloudWidth * range(random, 0.17, 0.29);
-        const progress = index / Math.max(1, Math.ceil(width / (620 - layerIndex * 70)) + layer.count - 1);
-        return {
-          ...createCloudShape(random, cloudWidth, cloudHeight, layer.depth),
-          baseX: -cloudWidth * 0.72 + progress * (width + cloudWidth * 1.36) + range(random, -cloudWidth * 0.16, cloudWidth * 0.16),
-          y: height * range(random, ...layer.y) - cloudHeight * range(random, 0.08, 0.2),
-          width: cloudWidth,
-          height: cloudHeight,
-          depth: layer.depth,
-          direction: (index + layerIndex) % 2 === 0 ? 1 : -1,
-          speed: range(random, ...layer.speed),
-          opacity: range(random, 0.48, 0.72),
-          hue: range(random, 34, 45),
-          phase: range(random, 0, Math.PI * 2),
-          floatAmplitude: range(random, 1.5, 5.5) * layer.depth,
-          floatSpeed: range(random, 0.55, 1.1),
-          gap: cloudWidth * range(random, 0.04, 0.18),
-        };
-      })
+      Array.from(
+        { length: Math.ceil(width / (620 - layerIndex * 70)) + layer.count },
+        (_, index) => {
+          const cloudWidth = Math.min(
+            width * 1.08 + 180,
+            Math.max(260, width * range(random, ...layer.width)),
+          );
+          const cloudHeight = cloudWidth * range(random, 0.17, 0.29);
+          const progress =
+            index / Math.max(1, Math.ceil(width / (620 - layerIndex * 70)) + layer.count - 1);
+          return {
+            ...createCloudShape(random, cloudWidth, cloudHeight, layer.depth),
+            baseX:
+              -cloudWidth * 0.72 +
+              progress * (width + cloudWidth * 1.36) +
+              range(random, -cloudWidth * 0.16, cloudWidth * 0.16),
+            y: height * range(random, ...layer.y) - cloudHeight * range(random, 0.08, 0.2),
+            width: cloudWidth,
+            height: cloudHeight,
+            depth: layer.depth,
+            direction: (index + layerIndex) % 2 === 0 ? 1 : -1,
+            speed: range(random, ...layer.speed),
+            opacity: range(random, 0.48, 0.72),
+            hue: range(random, 34, 45),
+            phase: range(random, 0, Math.PI * 2),
+            floatAmplitude: range(random, 1.5, 5.5) * layer.depth,
+            floatSpeed: range(random, 0.55, 1.1),
+            gap: cloudWidth * range(random, 0.04, 0.18),
+          };
+        },
+      ),
     )
     .sort((a, b) => a.depth - b.depth);
 }
@@ -192,15 +215,26 @@ function drawBackground(ctx, width, height, clouds, time, options, reducedMotion
   clouds.forEach((cloud) => {
     const motion = reducedMotion ? 0 : time * 0.001 * cloud.speed * cloud.direction * options.speed;
     const span = width + cloud.width + cloud.gap;
-    const x = ((cloud.baseX + motion + cloud.width) % span + span) % span - cloud.width;
-    const bob = reducedMotion ? 0 : Math.sin(time * 0.00032 * cloud.floatSpeed + cloud.phase) * cloud.floatAmplitude;
+    const x = ((((cloud.baseX + motion + cloud.width) % span) + span) % span) - cloud.width;
+    const bob = reducedMotion
+      ? 0
+      : Math.sin(time * 0.00032 * cloud.floatSpeed + cloud.phase) * cloud.floatAmplitude;
     const positions = [x];
     if (x > 0) positions.push(x - span);
     if (x + cloud.width < width) positions.push(x + span);
-    positions.forEach((position) => drawCloud(ctx, cloud, position, cloud.y + bob, options.opacity));
+    positions.forEach((position) =>
+      drawCloud(ctx, cloud, position, cloud.y + bob, options.opacity),
+    );
   });
 
-  const vignette = ctx.createRadialGradient(width * 0.46, height * 0.22, 0, width * 0.46, height * 0.22, Math.max(width, height) * 0.82);
+  const vignette = ctx.createRadialGradient(
+    width * 0.46,
+    height * 0.22,
+    0,
+    width * 0.46,
+    height * 0.22,
+    Math.max(width, height) * 0.82,
+  );
   vignette.addColorStop(0, "rgba(255, 255, 252, 0.22)");
   vignette.addColorStop(0.72, "rgba(139, 200, 246, 0.055)");
   vignette.addColorStop(1, "rgba(105, 106, 109, 0.11)");
@@ -229,7 +263,15 @@ function useCloudCanvas(canvasRef, options = DEFAULTS) {
       canvas.height = Math.max(1, Math.floor(height * dpr));
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       clouds = createClouds(width, height, settings.seed);
-      drawBackground(ctx, width, height, clouds, performance.now(), settings, mediaQuery?.matches ?? false);
+      drawBackground(
+        ctx,
+        width,
+        height,
+        clouds,
+        performance.now(),
+        settings,
+        mediaQuery?.matches ?? false,
+      );
     };
 
     const tick = (time) => {

--- a/components/__tests__/CraftDetail.test.js
+++ b/components/__tests__/CraftDetail.test.js
@@ -11,7 +11,7 @@ describe("CraftDetail", () => {
       before="No results found."
       after="No reports on this route yet."
       why="Turns a dead end into an instruction."
-    />
+    />,
   );
 
   test("labels the module as a concept example", () => {

--- a/components/__tests__/Principles.test.js
+++ b/components/__tests__/Principles.test.js
@@ -1,32 +1,32 @@
-import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
-import Principles from '../Principles';
+import Principles from "../Principles";
 
 const PRINCIPLE_TITLES = [
-  'Map the business process before the UI',
-  'Design for experts without punishing beginners',
-  'Use systems to pay down decision debt',
-  'Treat implementation as part of the design',
-  'Use AI to support judgment, not replace it',
-  'Name states, permissions, and errors early',
-  'Measure quality by outcomes, not output',
+  "Map the business process before the UI",
+  "Design for experts without punishing beginners",
+  "Use systems to pay down decision debt",
+  "Treat implementation as part of the design",
+  "Use AI to support judgment, not replace it",
+  "Name states, permissions, and errors early",
+  "Measure quality by outcomes, not output",
 ];
 
-describe('Principles', () => {
-  test('renders every principle title', () => {
+describe("Principles", () => {
+  test("renders every principle title", () => {
     const html = renderToStaticMarkup(<Principles />);
     PRINCIPLE_TITLES.forEach((title) => {
       expect(html).toContain(title);
     });
   });
 
-  test('exposes an accessible label', () => {
+  test("exposes an accessible label", () => {
     const html = renderToStaticMarkup(<Principles />);
     expect(html).toContain('aria-label="How I approach the work"');
   });
 
-  test('pairs each principle with a concrete detail sentence', () => {
+  test("pairs each principle with a concrete detail sentence", () => {
     const html = renderToStaticMarkup(<Principles />);
     const details = html.match(/principles__detail/g) || [];
     expect(details).toHaveLength(PRINCIPLE_TITLES.length);

--- a/components/__tests__/WritingCloudBackground.test.js
+++ b/components/__tests__/WritingCloudBackground.test.js
@@ -7,7 +7,7 @@ describe("WritingCloudBackground", () => {
 
     expect(Array.from({ length: 5 }, first)).toEqual(Array.from({ length: 5 }, second));
     expect(Array.from({ length: 5 }, seededRandom("writing"))).not.toEqual(
-      Array.from({ length: 5 }, seededRandom("other"))
+      Array.from({ length: 5 }, seededRandom("other")),
     );
   });
 

--- a/components/design-system/CasePlaceholders.js
+++ b/components/design-system/CasePlaceholders.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { colors, radii } from './tokens';
+import React from "react";
+import PropTypes from "prop-types";
+import { colors, radii } from "./tokens";
 
 // Presentational scaffolding for the design-system case shell.
 // Both components make incomplete areas obvious on the page itself, so the
@@ -61,7 +61,7 @@ ArtifactPlaceholder.propTypes = {
 };
 
 ArtifactPlaceholder.defaultProps = {
-  className: '',
+  className: "",
 };
 
 export const TbdNote = ({ children, className }) => (
@@ -102,5 +102,5 @@ TbdNote.propTypes = {
 
 TbdNote.defaultProps = {
   children: null,
-  className: '',
+  className: "",
 };

--- a/components/design-system/CraftDetail.js
+++ b/components/design-system/CraftDetail.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { colors, radii, shadows } from './tokens';
+import React from "react";
+import PropTypes from "prop-types";
+import { colors, radii, shadows } from "./tokens";
 
 // A compact before/after module for showing product-behavior craft:
 // loading states, error recovery, empty states, and microcopy tone.
@@ -145,7 +145,7 @@ CraftDetail.propTypes = {
 };
 
 CraftDetail.defaultProps = {
-  className: '',
+  className: "",
 };
 
 export default CraftDetail;

--- a/pages/Home.js
+++ b/pages/Home.js
@@ -189,20 +189,20 @@ class Home extends Component {
           <Row
             content={
               <p className="col-xs-12 col-sm-10 col-md-9 col-lg-7 col-xl-6 section-copy">
-                I came to product design through front-end work, so I spec the way engineers
-                read: every component arrives with its states, validation rules, responsive
-                behavior, and accessibility expectations written down — not discovered in a code
-                review. That background changes the questions I ask, not the work I do: I flag
-                what the backend can’t promise before it becomes a UI bug, and I’m in the pull
-                requests when a state I drew meets data I didn’t expect.
+                I came to product design through front-end work, so I spec the way engineers read:
+                every component arrives with its states, validation rules, responsive behavior, and
+                accessibility expectations written down — not discovered in a code review. That
+                background changes the questions I ask, not the work I do: I flag what the backend
+                can’t promise before it becomes a UI bug, and I’m in the pull requests when a state
+                I drew meets data I didn’t expect.
               </p>
             }
           />
           <Row
             content={
               <p className="col-xs-12 col-sm-10 col-md-9 col-lg-7 col-xl-6 section-copy artifacts-copy">
-                It’s still design work — the spec exists so the intent survives the build.
-                Here’s the shape of one, end to end.
+                It’s still design work — the spec exists so the intent survives the build. Here’s
+                the shape of one, end to end.
               </p>
             }
           />

--- a/pages/about.js
+++ b/pages/about.js
@@ -184,8 +184,8 @@ class About extends Component {
           <Row
             content={
               <p className="about-me-copy col-xs-12 col-sm-12 col-md-offset-2 col-md-8 col-lg-offset-3 col-lg-6 col-xl-6">
-                A few principles that shape most of what I design — the
-                judgment underneath the case studies.
+                A few principles that shape most of what I design — the judgment underneath the case
+                studies.
               </p>
             }
           />

--- a/pages/ai-decision-support.js
+++ b/pages/ai-decision-support.js
@@ -1,15 +1,12 @@
-import React from 'react';
+import React from "react";
 
-import CaseStudyMeta from '../components/CaseStudyMeta';
-import ProjectPage from '../components/ProjectPage';
-import ProjectSection from '../components/ProjectSection';
-import Row from '../components/Row';
-import {
-  ArtifactPlaceholder,
-  TbdNote,
-} from '../components/design-system/CasePlaceholders';
+import CaseStudyMeta from "../components/CaseStudyMeta";
+import ProjectPage from "../components/ProjectPage";
+import ProjectSection from "../components/ProjectSection";
+import Row from "../components/Row";
+import { ArtifactPlaceholder, TbdNote } from "../components/design-system/CasePlaceholders";
 
-import placeholderTexture from '../static/media/pohja.svg';
+import placeholderTexture from "../static/media/pohja.svg";
 
 // NOTE: This case is intentionally kept out of the Projects manifest
 // (components/Projects.js) and the primary nav. It is a publish-safe
@@ -39,53 +36,58 @@ import placeholderTexture from '../static/media/pohja.svg';
 //    decisions and reasoning over confidential detail.
 
 const pStyle =
-  'col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6';
+  "col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6";
 
 const AiDecisionSupportCase = () => (
   <div className="AiDecisionSupportCase">
     <ProjectPage
-      projectName={'AI Decision Support'}
-      title={'Designing AI as Decision Support in an Operational Workflow'}
+      projectName={"AI Decision Support"}
+      title={"Designing AI as Decision Support in an Operational Workflow"}
       hero={placeholderTexture}
       heroAlt={
-        'Placeholder texture for the AI decision-support concept case — recreated workflow artwork pending.'
+        "Placeholder texture for the AI decision-support concept case — recreated workflow artwork pending."
       }
-      eyebrow={'Concept shell — design framework, not shipped work'}
-      navbarColor={'purple'}
+      eyebrow={"Concept shell — design framework, not shipped work"}
+      navbarColor={"purple"}
       showNextProject={false}
       description={
-        'A design framework for putting machine predictions inside a human decision workflow: what the user is deciding, what evidence they inspect, where a model can genuinely help, and what has to be true about confidence, override, and accountability before anyone should trust it.'
+        "A design framework for putting machine predictions inside a human decision workflow: what the user is deciding, what evidence they inspect, where a model can genuinely help, and what has to be true about confidence, override, and accountability before anyone should trust it."
       }
       content={
         <span>
           <CaseStudyMeta
-            status={'Concept shell — no shipped AI evidence claimed'}
+            status={"Concept shell — no shipped AI evidence claimed"}
             summary={
-              'A capability case about designing AI into complex, trust-sensitive B2B workflows. The premise: in operational domains, AI earns its place as decision support — a well-behaved input into a human decision — not as a novelty layer or a chatbot bolted onto the side. This page documents the structure and principles I design against.'
+              "A capability case about designing AI into complex, trust-sensitive B2B workflows. The premise: in operational domains, AI earns its place as decision support — a well-behaved input into a human decision — not as a novelty layer or a chatbot bolted onto the side. This page documents the structure and principles I design against."
             }
             note={
-              'This is a concept and framework page, marked as such throughout. It contains no shipped AI product, no model performance numbers, and no client evidence — those are shown as pending artifacts and will only ever be filled with real, cleared, anonymized material. The design judgment on this page is the evidence it offers.'
+              "This is a concept and framework page, marked as such throughout. It contains no shipped AI product, no model performance numbers, and no client evidence — those are shown as pending artifacts and will only ever be filled with real, cleared, anonymized material. The design judgment on this page is the evidence it offers."
             }
             fields={{
               context:
-                'Concept setting: an operational domain where a specialist reviews incoming data and makes consequential accept / flag / escalate decisions under time pressure — the workflow shape shared by inspection, monitoring, triage, and quality-control work.',
+                "Concept setting: an operational domain where a specialist reviews incoming data and makes consequential accept / flag / escalate decisions under time pressure — the workflow shape shared by inspection, monitoring, triage, and quality-control work.",
               problem:
-                'Problem type: the decision itself is sound but expensive — high volume, high vigilance cost, error consequences that are asymmetric. The design question is where machine assistance genuinely reduces that load without displacing accountability.',
+                "Problem type: the decision itself is sound but expensive — high volume, high vigilance cost, error consequences that are asymmetric. The design question is where machine assistance genuinely reduces that load without displacing accountability.",
               constraints:
-                'Wrong decisions are costly and traceability is mandatory, so the design must assume the model will sometimes be wrong and make that survivable: visible uncertainty, inspectable evidence, human override, and a working fallback path are requirements, not enhancements.',
+                "Wrong decisions are costly and traceability is mandatory, so the design must assume the model will sometimes be wrong and make that survivable: visible uncertainty, inspectable evidence, human override, and a working fallback path are requirements, not enhancements.",
               proxyEvidence:
-                'Until a shipped case can be documented, the evidence here is the framework itself: the section structure below is the checklist I hold AI features against, and each section states the design position it encodes.',
+                "Until a shipped case can be documented, the evidence here is the framework itself: the section structure below is the checklist I hold AI features against, and each section states the design position it encodes.",
             }}
           />
 
           <ProjectSection
-            title={'The task before AI'}
+            title={"The task before AI"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Every credible AI feature starts with a precise account of the work as it exists without the model. Who decides, on what cadence, with what consequences when they are wrong. If the task cannot be described crisply without mentioning AI, the AI has nothing concrete to support — and the feature is decoration. Writing this account first also sets the baseline that any later measurement of the AI has to beat.
+                      Every credible AI feature starts with a precise account of the work as it
+                      exists without the model. Who decides, on what cadence, with what consequences
+                      when they are wrong. If the task cannot be described crisply without
+                      mentioning AI, the AI has nothing concrete to support — and the feature is
+                      decoration. Writing this account first also sets the baseline that any later
+                      measurement of the AI has to beat.
                     </p>
                   }
                 />
@@ -93,9 +95,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Task model'}
+                      title={"Task model"}
                       prompt={
-                        'TODO (real project only): a recreated, anonymized model of the human task — the decision being made, its inputs, its frequency, and the cost of each kind of error. Neutral role labels; no client or system names.'
+                        "TODO (real project only): a recreated, anonymized model of the human task — the decision being made, its inputs, its frequency, and the cost of each kind of error. Neutral role labels; no client or system names."
                       }
                     />
                   }
@@ -105,13 +107,19 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Cognitive load'}
+            title={"Cognitive load"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      The honest reason to add AI to a workflow is usually cognitive: sustained vigilance over mostly-normal data, comparisons across more items than working memory holds, or pattern checks that fatigue erodes over a shift. Locating exactly where attention is being spent — and where it degrades — tells you what the model should absorb. It also tells you what it must not absorb: the judgment calls where human context, accountability, and situational knowledge do the real work.
+                      The honest reason to add AI to a workflow is usually cognitive: sustained
+                      vigilance over mostly-normal data, comparisons across more items than working
+                      memory holds, or pattern checks that fatigue erodes over a shift. Locating
+                      exactly where attention is being spent — and where it degrades — tells you
+                      what the model should absorb. It also tells you what it must not absorb: the
+                      judgment calls where human context, accountability, and situational knowledge
+                      do the real work.
                     </p>
                   }
                 />
@@ -119,9 +127,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Attention map'}
+                      title={"Attention map"}
                       prompt={
-                        'TODO (real project only): an anonymized map of where the specialist’s attention goes across a work session — which checks are exhausting, which are trivial, where errors cluster in time. This is the artifact that justifies (or kills) the AI feature.'
+                        "TODO (real project only): an anonymized map of where the specialist’s attention goes across a work session — which checks are exhausting, which are trivial, where errors cluster in time. This is the artifact that justifies (or kills) the AI feature."
                       }
                     />
                   }
@@ -131,13 +139,19 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'The data being inspected'}
+            title={"The data being inspected"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Decision-support design is data design. The user is already inspecting something — images, sensor streams, records, events — and their trust in any machine suggestion depends on being able to see the same evidence the suggestion points at. Cataloguing the data honestly matters: its volume and update rhythm, but also its failure modes — gaps, sensor noise, stale readings, ambiguous cases — because those are exactly the conditions under which a model quietly stops deserving trust.
+                      Decision-support design is data design. The user is already inspecting
+                      something — images, sensor streams, records, events — and their trust in any
+                      machine suggestion depends on being able to see the same evidence the
+                      suggestion points at. Cataloguing the data honestly matters: its volume and
+                      update rhythm, but also its failure modes — gaps, sensor noise, stale
+                      readings, ambiguous cases — because those are exactly the conditions under
+                      which a model quietly stops deserving trust.
                     </p>
                   }
                 />
@@ -145,9 +159,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Data inventory'}
+                      title={"Data inventory"}
                       prompt={
-                        'TODO (real project only): a recreated inventory of the inspected data — types, freshness, volume, known quality problems — with neutral labels. Mark which properties the interface must surface so the user can judge the evidence themselves.'
+                        "TODO (real project only): a recreated inventory of the inspected data — types, freshness, volume, known quality problems — with neutral labels. Mark which properties the interface must surface so the user can judge the evidence themselves."
                       }
                     />
                   }
@@ -157,20 +171,30 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Where AI enters — and where it does not'}
+            title={"Where AI enters — and where it does not"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      The support role has to be chosen, not assumed. A model can rank what deserves attention first, pre-fill what is tedious to enter, flag what deviates from normal, or draft an assessment for review — and each role implies a different interface contract. What stays constant is the boundary: the model proposes, the human disposes. A recommendation is an input to the decision, never the decision itself, and the interface should make acting against the model exactly as easy as acting with it.
+                      The support role has to be chosen, not assumed. A model can rank what deserves
+                      attention first, pre-fill what is tedious to enter, flag what deviates from
+                      normal, or draft an assessment for review — and each role implies a different
+                      interface contract. What stays constant is the boundary: the model proposes,
+                      the human disposes. A recommendation is an input to the decision, never the
+                      decision itself, and the interface should make acting against the model
+                      exactly as easy as acting with it.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <p className={pStyle}>
-                      Deliberately absent here: a chat window. Inspection-and-decision workflows are spatial and stateful — the user is looking at evidence, not composing prose — and forcing that through conversation adds friction while hiding the data. A conversational surface earns a place only when the workflow genuinely is a dialogue, and that need would have to show up in research, not in a trend.
+                      Deliberately absent here: a chat window. Inspection-and-decision workflows are
+                      spatial and stateful — the user is looking at evidence, not composing prose —
+                      and forcing that through conversation adds friction while hiding the data. A
+                      conversational surface earns a place only when the workflow genuinely is a
+                      dialogue, and that need would have to show up in research, not in a trend.
                     </p>
                   }
                 />
@@ -178,9 +202,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Support-role decision'}
+                      title={"Support-role decision"}
                       prompt={
-                        'TODO (real project only): the anonymized reasoning for which support role the model plays — options considered, the one chosen, and which decisions were deliberately left fully manual and why.'
+                        "TODO (real project only): the anonymized reasoning for which support role the model plays — options considered, the one chosen, and which decisions were deliberately left fully manual and why."
                       }
                     />
                   }
@@ -190,13 +214,20 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Confidence & uncertainty'}
+            title={"Confidence & uncertainty"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Uncertainty must be visible, and it must be designed against overtrust as much as undertrust. A raw probability invites false precision; a traffic light hides too much. The working position: express confidence in terms of what the user should do differently — “worth a look” versus “needs your judgment” versus “the model has little basis here” — and make low confidence loud rather than apologetic. The most dangerous state in decision support is a wrong suggestion delivered fluently, so the design treats calibrated doubt as a feature, not an embarrassment.
+                      Uncertainty must be visible, and it must be designed against overtrust as much
+                      as undertrust. A raw probability invites false precision; a traffic light
+                      hides too much. The working position: express confidence in terms of what the
+                      user should do differently — “worth a look” versus “needs your judgment”
+                      versus “the model has little basis here” — and make low confidence loud rather
+                      than apologetic. The most dangerous state in decision support is a wrong
+                      suggestion delivered fluently, so the design treats calibrated doubt as a
+                      feature, not an embarrassment.
                     </p>
                   }
                 />
@@ -204,9 +235,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Uncertainty display'}
+                      title={"Uncertainty display"}
                       prompt={
-                        'TODO (concept mock or real project): recreated UI showing how confidence is expressed at each decision point — including the explicit low-confidence and no-basis states, not just the happy path.'
+                        "TODO (concept mock or real project): recreated UI showing how confidence is expressed at each decision point — including the explicit low-confidence and no-basis states, not just the happy path."
                       }
                     />
                   }
@@ -216,13 +247,19 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Explainability & inspectable evidence'}
+            title={"Explainability & inspectable evidence"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      “Why is the system suggesting this?” must have an answer a practitioner can check, in the vocabulary of their domain. That rarely means exposing model internals; it means pointing at evidence — the region of the image, the readings that deviated, the past cases this one resembles — so the user can agree or disagree with the suggestion on its merits. Explanation the user cannot verify is reassurance, not explainability, and reassurance is precisely what a trust-sensitive workflow does not need.
+                      “Why is the system suggesting this?” must have an answer a practitioner can
+                      check, in the vocabulary of their domain. That rarely means exposing model
+                      internals; it means pointing at evidence — the region of the image, the
+                      readings that deviated, the past cases this one resembles — so the user can
+                      agree or disagree with the suggestion on its merits. Explanation the user
+                      cannot verify is reassurance, not explainability, and reassurance is precisely
+                      what a trust-sensitive workflow does not need.
                     </p>
                   }
                 />
@@ -230,9 +267,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Evidence view'}
+                      title={"Evidence view"}
                       prompt={
-                        'TODO (concept mock or real project): recreated UI for the evidence behind a suggestion — what the model looked at, surfaced in domain terms, one interaction away from the recommendation itself.'
+                        "TODO (concept mock or real project): recreated UI for the evidence behind a suggestion — what the model looked at, surfaced in domain terms, one interaction away from the recommendation itself."
                       }
                     />
                   }
@@ -242,13 +279,20 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Human override & control'}
+            title={"Human override & control"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Override is a first-class action, not an escape hatch. The user can reject, correct, or annotate any suggestion without justifying themselves to the interface, without extra friction, and without the system nagging them back toward agreement. Defaults matter most here: nothing consequential proceeds on model output alone, and “accept” is a deliberate act rather than the path of least resistance. The accountability structure stays intact — the person who decides is the person the organization already holds responsible, and the interface never blurs that.
+                      Override is a first-class action, not an escape hatch. The user can reject,
+                      correct, or annotate any suggestion without justifying themselves to the
+                      interface, without extra friction, and without the system nagging them back
+                      toward agreement. Defaults matter most here: nothing consequential proceeds on
+                      model output alone, and “accept” is a deliberate act rather than the path of
+                      least resistance. The accountability structure stays intact — the person who
+                      decides is the person the organization already holds responsible, and the
+                      interface never blurs that.
                     </p>
                   }
                 />
@@ -256,9 +300,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Override flow'}
+                      title={"Override flow"}
                       prompt={
-                        'TODO (concept mock or real project): recreated flow for disagreeing with the model — reject, correct, annotate — showing that it costs no more effort than accepting.'
+                        "TODO (concept mock or real project): recreated flow for disagreeing with the model — reject, correct, annotate — showing that it costs no more effort than accepting."
                       }
                     />
                   }
@@ -268,13 +312,19 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Error states & fallback'}
+            title={"Error states & fallback"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      The system will be wrong, late, or unavailable, and the workflow has to survive all three. That means designing the degraded modes explicitly: what the screen says when the model has no answer, how stale predictions are marked before they mislead, and — most importantly — a manual path that remains a complete, practiced way to do the job. If the fallback only exists in documentation, the AI has become a single point of failure wearing a helpful face.
+                      The system will be wrong, late, or unavailable, and the workflow has to
+                      survive all three. That means designing the degraded modes explicitly: what
+                      the screen says when the model has no answer, how stale predictions are marked
+                      before they mislead, and — most importantly — a manual path that remains a
+                      complete, practiced way to do the job. If the fallback only exists in
+                      documentation, the AI has become a single point of failure wearing a helpful
+                      face.
                     </p>
                   }
                 />
@@ -282,9 +332,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Degraded-mode states'}
+                      title={"Degraded-mode states"}
                       prompt={
-                        'TODO (concept mock or real project): the recreated state inventory — no prediction, low-quality input, stale output, service down — and the manual path the user follows in each. These states get designed with the same care as the happy path.'
+                        "TODO (concept mock or real project): the recreated state inventory — no prediction, low-quality input, stale output, service down — and the manual path the user follows in each. These states get designed with the same care as the happy path."
                       }
                     />
                   }
@@ -294,13 +344,19 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Feedback loops'}
+            title={"Feedback loops"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Every override, correction, and confirmation is signal — about the model, and just as often about the data or the workflow around it. The design questions are consent and honesty: users should know what their corrections are used for, feedback capture should ride inside actions they already take rather than adding chores, and disagreement must never be treated as user error. A feedback loop users understand builds the habit of correcting the system; one they distrust teaches them to route around it.
+                      Every override, correction, and confirmation is signal — about the model, and
+                      just as often about the data or the workflow around it. The design questions
+                      are consent and honesty: users should know what their corrections are used
+                      for, feedback capture should ride inside actions they already take rather than
+                      adding chores, and disagreement must never be treated as user error. A
+                      feedback loop users understand builds the habit of correcting the system; one
+                      they distrust teaches them to route around it.
                     </p>
                   }
                 />
@@ -308,9 +364,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Feedback capture'}
+                      title={"Feedback capture"}
                       prompt={
-                        'TODO (real project only): the anonymized design for how corrections flow back — what is captured, what the user is told about its use, and how the loop avoided becoming unpaid labeling work.'
+                        "TODO (real project only): the anonymized design for how corrections flow back — what is captured, what the user is told about its use, and how the loop avoided becoming unpaid labeling work."
                       }
                     />
                   }
@@ -320,13 +376,19 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Audit trail'}
+            title={"Audit trail"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      In trust-sensitive domains, “what did the system suggest, what did the person decide, and what did they see at the time” must be answerable months later. The audit trail records suggestion, confidence, evidence shown, and the human action taken — and it exists to make decisions reconstructable, not to put operators under surveillance. That distinction is a design decision with real consequences for whether people use the system honestly, and it deserves the same intent as any screen.
+                      In trust-sensitive domains, “what did the system suggest, what did the person
+                      decide, and what did they see at the time” must be answerable months later.
+                      The audit trail records suggestion, confidence, evidence shown, and the human
+                      action taken — and it exists to make decisions reconstructable, not to put
+                      operators under surveillance. That distinction is a design decision with real
+                      consequences for whether people use the system honestly, and it deserves the
+                      same intent as any screen.
                     </p>
                   }
                 />
@@ -334,9 +396,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Decision record'}
+                      title={"Decision record"}
                       prompt={
-                        'TODO (concept mock or real project): a recreated decision record — model suggestion, confidence, evidence displayed, human action, timestamp — with neutral data, plus the reasoning about who can read it and why.'
+                        "TODO (concept mock or real project): a recreated decision record — model suggestion, confidence, evidence displayed, human action, timestamp — with neutral data, plus the reasoning about who can read it and why."
                       }
                     />
                   }
@@ -346,13 +408,19 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Risk guardrails'}
+            title={"Risk guardrails"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Some failures should be structurally impossible rather than merely discouraged. Guardrails are decided per decision, with the domain’s risk owners at the table: which actions always require human confirmation regardless of confidence, which are capped in scope or reversible by design, and where automation is refused outright because the error asymmetry is too steep. Writing these down early also keeps scope honest — a guardrail agreed on paper is much harder to erode later under delivery pressure.
+                      Some failures should be structurally impossible rather than merely
+                      discouraged. Guardrails are decided per decision, with the domain’s risk
+                      owners at the table: which actions always require human confirmation
+                      regardless of confidence, which are capped in scope or reversible by design,
+                      and where automation is refused outright because the error asymmetry is too
+                      steep. Writing these down early also keeps scope honest — a guardrail agreed
+                      on paper is much harder to erode later under delivery pressure.
                     </p>
                   }
                 />
@@ -360,9 +428,9 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Guardrail matrix'}
+                      title={"Guardrail matrix"}
                       prompt={
-                        'TODO (real project only): the anonymized matrix of decisions × automation level — fully manual, suggest-only, suggest-with-confirmation — and the reasoning for each boundary.'
+                        "TODO (real project only): the anonymized matrix of decisions × automation level — fully manual, suggest-only, suggest-with-confirmation — and the reasoning for each boundary."
                       }
                     />
                   }
@@ -372,20 +440,29 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Measurement plan'}
+            title={"Measurement plan"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      The AI is worth keeping only if the human decision gets better or cheaper without new failure modes — so the plan measures the joint human-plus-model outcome against the pre-AI baseline, not model accuracy in isolation. Alongside decision quality and time: override rates and their trend, calibration between stated confidence and actual correctness, and drift in user behavior — because both blind acceptance and silent abandonment are failure modes that a healthy accuracy number can hide.
+                      The AI is worth keeping only if the human decision gets better or cheaper
+                      without new failure modes — so the plan measures the joint human-plus-model
+                      outcome against the pre-AI baseline, not model accuracy in isolation.
+                      Alongside decision quality and time: override rates and their trend,
+                      calibration between stated confidence and actual correctness, and drift in
+                      user behavior — because both blind acceptance and silent abandonment are
+                      failure modes that a healthy accuracy number can hide.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      No results are reported here because none are claimed. When a real deployment can be documented, this section carries measured outcomes if they are real, attributable, and cleared — and structural proxy evidence otherwise. Nothing gets invented to make the concept look shipped.
+                      No results are reported here because none are claimed. When a real deployment
+                      can be documented, this section carries measured outcomes if they are real,
+                      attributable, and cleared — and structural proxy evidence otherwise. Nothing
+                      gets invented to make the concept look shipped.
                     </TbdNote>
                   }
                 />
@@ -394,13 +471,14 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Working principles'}
+            title={"Working principles"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      The compact version of everything above — the positions I hold AI features against before any of them reaches a screen:
+                      The compact version of everything above — the positions I hold AI features
+                      against before any of them reaches a screen:
                     </p>
                   }
                 />
@@ -408,19 +486,28 @@ const AiDecisionSupportCase = () => (
                   content={
                     <ul className={pStyle}>
                       <li>
-                        <strong>A recommendation is not an action.</strong> The model proposes; a person decides. Consequential steps never proceed on model output alone.
+                        <strong>A recommendation is not an action.</strong> The model proposes; a
+                        person decides. Consequential steps never proceed on model output alone.
                       </li>
                       <li>
-                        <strong>Confidence is visible — and designed against overtrust.</strong> Uncertainty is expressed in terms of what the user should do, and low confidence is presented loudly, not apologetically.
+                        <strong>Confidence is visible — and designed against overtrust.</strong>{" "}
+                        Uncertainty is expressed in terms of what the user should do, and low
+                        confidence is presented loudly, not apologetically.
                       </li>
                       <li>
-                        <strong>Evidence is inspectable.</strong> Every suggestion points at checkable evidence in the practitioner’s own vocabulary. Explanation you cannot verify is reassurance, not explainability.
+                        <strong>Evidence is inspectable.</strong> Every suggestion points at
+                        checkable evidence in the practitioner’s own vocabulary. Explanation you
+                        cannot verify is reassurance, not explainability.
                       </li>
                       <li>
-                        <strong>The user stays in control.</strong> Overriding is as easy as accepting, requires no justification to the interface, and leaves accountability where the organization already places it.
+                        <strong>The user stays in control.</strong> Overriding is as easy as
+                        accepting, requires no justification to the interface, and leaves
+                        accountability where the organization already places it.
                       </li>
                       <li>
-                        <strong>A fallback path exists — and works.</strong> The workflow survives the model being wrong, late, or absent, because the manual path is complete and practiced, not theoretical.
+                        <strong>A fallback path exists — and works.</strong> The workflow survives
+                        the model being wrong, late, or absent, because the manual path is complete
+                        and practiced, not theoretical.
                       </li>
                     </ul>
                   }
@@ -430,20 +517,28 @@ const AiDecisionSupportCase = () => (
           />
 
           <ProjectSection
-            title={'Why this shape'}
+            title={"Why this shape"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      This framework is the AI-specific edge of the same practice as my operational-product work: complex B2B domains, many roles, decisions with real consequences, and trust that has to be built structurally rather than claimed. The order of the sections is the argument — task and data before model, uncertainty and override before polish, measurement before celebration. That is also why this page is labeled a concept shell instead of dressed up as a case study: in trust-sensitive design, not overclaiming is part of the craft.
+                      This framework is the AI-specific edge of the same practice as my
+                      operational-product work: complex B2B domains, many roles, decisions with real
+                      consequences, and trust that has to be built structurally rather than claimed.
+                      The order of the sections is the argument — task and data before model,
+                      uncertainty and override before polish, measurement before celebration. That
+                      is also why this page is labeled a concept shell instead of dressed up as a
+                      case study: in trust-sensitive design, not overclaiming is part of the craft.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      When real AI-assisted workflow projects can be documented and cleared, they attach here under the same anonymization rules as the rest of the portfolio — recreated artifacts, neutral labels, decisions over confidential detail.
+                      When real AI-assisted workflow projects can be documented and cleared, they
+                      attach here under the same anonymization rules as the rest of the portfolio —
+                      recreated artifacts, neutral labels, decisions over confidential detail.
                     </TbdNote>
                   }
                 />

--- a/pages/aikakone.js
+++ b/pages/aikakone.js
@@ -508,8 +508,8 @@ class Aikakone extends Component {
                     <Row
                       content={
                         <p className={pStyle}>
-                          The PowerPoint prototype never had to load, fail, or save anything real.
-                          A production memory-care tool would earn or lose trust in exactly those
+                          The PowerPoint prototype never had to load, fail, or save anything real. A
+                          production memory-care tool would earn or lose trust in exactly those
                           moments, so the concept examples below show how I would design the states
                           the prototype never reached.
                         </p>

--- a/pages/design-system.js
+++ b/pages/design-system.js
@@ -1,16 +1,13 @@
-import React from 'react';
+import React from "react";
 
-import CaseStudyMeta from '../components/CaseStudyMeta';
-import ProjectPage from '../components/ProjectPage';
-import ProjectSection from '../components/ProjectSection';
-import Row from '../components/Row';
-import {
-  ArtifactPlaceholder,
-  TbdNote,
-} from '../components/design-system/CasePlaceholders';
-import { colors, radii, shadows } from '../components/design-system/tokens';
+import CaseStudyMeta from "../components/CaseStudyMeta";
+import ProjectPage from "../components/ProjectPage";
+import ProjectSection from "../components/ProjectSection";
+import Row from "../components/Row";
+import { ArtifactPlaceholder, TbdNote } from "../components/design-system/CasePlaceholders";
+import { colors, radii, shadows } from "../components/design-system/tokens";
 
-import placeholderTexture from '../static/media/pohja.svg';
+import placeholderTexture from "../static/media/pohja.svg";
 
 // NOTE: This case is intentionally kept out of the Projects manifest
 // (components/Projects.js) and the primary nav. It is a publish-safe shell:
@@ -18,71 +15,86 @@ import placeholderTexture from '../static/media/pohja.svg';
 // component screenshots, token tables, and QA evidence are attached.
 
 const pStyle =
-  'col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6';
+  "col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6";
 
 // Real values from components/design-system/tokens.js. This table is honest
 // infrastructure evidence: these tokens already drive shadows, radii, and
 // accents across this site, so the mapping section can start from fact.
 const TOKEN_ROWS = [
-  { token: 'colors.accentPurple', value: colors.accentPurple, role: 'Signal accent, progress + emphasis' },
-  { token: 'colors.markerHighlight', value: 'rgba(139,200,246,0.57)', role: 'Inline marker highlight' },
-  { token: 'colors.textStrong', value: colors.textStrong, role: 'Primary text + anchors' },
-  { token: 'colors.textMuted', value: colors.textMuted, role: 'Secondary text, quiet UI' },
-  { token: 'radii.pill', value: radii.pill, role: 'Buttons, tags, metadata pills' },
-  { token: 'shadows.media', value: shadows.media, role: 'Default media elevation' },
-  { token: 'shadows.card', value: shadows.card, role: 'Foreground summary panels' },
-  { token: 'transitions.smooth', value: 'all .6s linear', role: 'Accent + hover transitions' },
+  {
+    token: "colors.accentPurple",
+    value: colors.accentPurple,
+    role: "Signal accent, progress + emphasis",
+  },
+  {
+    token: "colors.markerHighlight",
+    value: "rgba(139,200,246,0.57)",
+    role: "Inline marker highlight",
+  },
+  { token: "colors.textStrong", value: colors.textStrong, role: "Primary text + anchors" },
+  { token: "colors.textMuted", value: colors.textMuted, role: "Secondary text, quiet UI" },
+  { token: "radii.pill", value: radii.pill, role: "Buttons, tags, metadata pills" },
+  { token: "shadows.media", value: shadows.media, role: "Default media elevation" },
+  { token: "shadows.card", value: shadows.card, role: "Foreground summary panels" },
+  { token: "transitions.smooth", value: "all .6s linear", role: "Accent + hover transitions" },
 ];
 
 const DesignSystemCase = () => (
   <div className="DesignSystemCase">
     <ProjectPage
-      projectName={'Design System'}
-      title={'Scaling Product Consistency Through a Design System'}
+      projectName={"Design System"}
+      title={"Scaling Product Consistency Through a Design System"}
       hero={placeholderTexture}
-      heroAlt={'Placeholder texture for the design system case — real component artwork pending.'}
-      eyebrow={'Case shell — in progress'}
-      navbarColor={'purple'}
+      heroAlt={"Placeholder texture for the design system case — real component artwork pending."}
+      eyebrow={"Case shell — in progress"}
+      navbarColor={"purple"}
       showNextProject={false}
       description={
-        'How components, tokens, documentation, and implementation QA turn scattered UI decisions into shared product infrastructure that teams can build on.'
+        "How components, tokens, documentation, and implementation QA turn scattered UI decisions into shared product infrastructure that teams can build on."
       }
       content={
         <span>
           <CaseStudyMeta
-            status={'Case shell — in progress'}
+            status={"Case shell — in progress"}
             summary={
-              'A capability case about design systems as product infrastructure: components and tokens are the visible surface, but the real work is documentation, developer handoff, and QA that keep consistency holding as more people ship.'
+              "A capability case about design systems as product infrastructure: components and tokens are the visible surface, but the real work is documentation, developer handoff, and QA that keep consistency holding as more people ship."
             }
             note={
-              'This page is a structured shell. The framing and section scaffolding are real; component screenshots, variant matrices, and measured outcomes are marked as pending and will be replaced with concrete evidence. Nothing here claims a specific employer, shipped product, or metric that is not yet documented.'
+              "This page is a structured shell. The framing and section scaffolding are real; component screenshots, variant matrices, and measured outcomes are marked as pending and will be replaced with concrete evidence. Nothing here claims a specific employer, shipped product, or metric that is not yet documented."
             }
             fields={{
               myRole:
-                'Design-systems and design-engineering work: component behavior, token structure, documentation, and implementation QA across the design-to-code boundary.',
-              team: 'To be completed with real evidence — collaborators, engineering partners, and scope of shared ownership are documented per project, not inflated here.',
+                "Design-systems and design-engineering work: component behavior, token structure, documentation, and implementation QA across the design-to-code boundary.",
+              team: "To be completed with real evidence — collaborators, engineering partners, and scope of shared ownership are documented per project, not inflated here.",
               context:
-                'Design system as shared product infrastructure: a component library, a token layer, and the docs and QA around them that let more than one person ship consistent UI.',
+                "Design system as shared product infrastructure: a component library, a token layer, and the docs and QA around them that let more than one person ship consistent UI.",
               problem:
-                'Problem type: keeping product UI consistent and maintainable as surface area, contributors, and platforms grow — a systems and infrastructure problem, not only a component-making one.',
+                "Problem type: keeping product UI consistent and maintainable as surface area, contributors, and platforms grow — a systems and infrastructure problem, not only a component-making one.",
             }}
           />
 
           <ProjectSection
-            title={'Problem'}
+            title={"Problem"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Consistency is easy at small scale and fragile at large scale. As a product grows more screens, more contributors, and more platforms, the same button, input, or spacing decision gets re-made slightly differently each time. The cost is not only visual: divergence slows engineering, weakens accessibility, and makes every future change more expensive.
+                      Consistency is easy at small scale and fragile at large scale. As a product
+                      grows more screens, more contributors, and more platforms, the same button,
+                      input, or spacing decision gets re-made slightly differently each time. The
+                      cost is not only visual: divergence slows engineering, weakens accessibility,
+                      and makes every future change more expensive.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <p className={pStyle}>
-                      The real problem a design system solves is infrastructure, not decoration. It has to make the correct UI the easy UI to build, hold up under real handoff pressure, and stay trustworthy through QA — so teams inherit consistency instead of negotiating it each sprint.
+                      The real problem a design system solves is infrastructure, not decoration. It
+                      has to make the correct UI the easy UI to build, hold up under real handoff
+                      pressure, and stay trustworthy through QA — so teams inherit consistency
+                      instead of negotiating it each sprint.
                     </p>
                   }
                 />
@@ -90,9 +102,9 @@ const DesignSystemCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Before / after inconsistency'}
+                      title={"Before / after inconsistency"}
                       prompt={
-                        'Insert a before/after showing the same component or flow rendered inconsistently across screens, then unified after the system. Annotate the specific divergences (radius, color, spacing, states) the system removed.'
+                        "Insert a before/after showing the same component or flow rendered inconsistently across screens, then unified after the system. Annotate the specific divergences (radius, color, spacing, states) the system removed."
                       }
                     />
                   }
@@ -102,20 +114,27 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'My role'}
+            title={"My role"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      This case sits on the design-to-code boundary: shaping component behavior and token structure, writing the documentation that makes them usable, and running the implementation QA that keeps the built product matching the intended system. It is design-engineering work, framed honestly around what can be evidenced.
+                      This case sits on the design-to-code boundary: shaping component behavior and
+                      token structure, writing the documentation that makes them usable, and running
+                      the implementation QA that keeps the built product matching the intended
+                      system. It is design-engineering work, framed honestly around what can be
+                      evidenced.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      Exact contribution boundaries, collaborators, and the split between individual and shared ownership will be described per project once the supporting artifacts are attached. No management or team-size claims are made beyond documented reality.
+                      Exact contribution boundaries, collaborators, and the split between individual
+                      and shared ownership will be described per project once the supporting
+                      artifacts are attached. No management or team-size claims are made beyond
+                      documented reality.
                     </TbdNote>
                   }
                 />
@@ -124,13 +143,15 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'Team'}
+            title={"Team"}
             content={
               <span>
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      Team composition, engineering partners, and the working model (who owned tokens, who owned implementation, how review happened) belong here with real names of roles, not inflated titles.
+                      Team composition, engineering partners, and the working model (who owned
+                      tokens, who owned implementation, how review happened) belong here with real
+                      names of roles, not inflated titles.
                     </TbdNote>
                   }
                 />
@@ -139,13 +160,17 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'System context'}
+            title={"System context"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      A component library is only the visible layer. Underneath it sits a token layer, a documentation surface, and a handoff and QA loop with engineering. A design system works as product infrastructure when those layers stay in sync: a token change propagates, the docs explain intent, and QA catches drift before it ships.
+                      A component library is only the visible layer. Underneath it sits a token
+                      layer, a documentation surface, and a handoff and QA loop with engineering. A
+                      design system works as product infrastructure when those layers stay in sync:
+                      a token change propagates, the docs explain intent, and QA catches drift
+                      before it ships.
                     </p>
                   }
                 />
@@ -153,9 +178,9 @@ const DesignSystemCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'System context map'}
+                      title={"System context map"}
                       prompt={
-                        'Insert a diagram of the system: design source, token layer, component library, documentation, and the implemented product — with the sync points and ownership boundaries between design and engineering marked.'
+                        "Insert a diagram of the system: design source, token layer, component library, documentation, and the implemented product — with the sync points and ownership boundaries between design and engineering marked."
                       }
                     />
                   }
@@ -165,13 +190,16 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'Component behavior'}
+            title={"Component behavior"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Good components are defined by behavior, not just appearance: what is fixed, what flexes, how they respond to content length, and how they compose. The system documents anatomy and the rules that keep a component correct wherever it lands — so a contributor cannot accidentally build an off-system variant.
+                      Good components are defined by behavior, not just appearance: what is fixed,
+                      what flexes, how they respond to content length, and how they compose. The
+                      system documents anatomy and the rules that keep a component correct wherever
+                      it lands — so a contributor cannot accidentally build an off-system variant.
                     </p>
                   }
                 />
@@ -179,9 +207,9 @@ const DesignSystemCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Component anatomy'}
+                      title={"Component anatomy"}
                       prompt={
-                        'Insert an anatomy breakdown of one signature component: labelled parts, spacing rules, slot behavior, and content constraints. Show how tokens map onto each part.'
+                        "Insert an anatomy breakdown of one signature component: labelled parts, spacing rules, slot behavior, and content constraints. Show how tokens map onto each part."
                       }
                     />
                   }
@@ -190,9 +218,9 @@ const DesignSystemCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Variant matrix'}
+                      title={"Variant matrix"}
                       prompt={
-                        'Insert a variant matrix for that component (size x emphasis x state, or equivalent). Show which combinations are supported, which are intentionally excluded, and why.'
+                        "Insert a variant matrix for that component (size x emphasis x state, or equivalent). Show which combinations are supported, which are intentionally excluded, and why."
                       }
                     />
                   }
@@ -202,13 +230,17 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'Token mapping'}
+            title={"Token mapping"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Tokens are the contract between design intent and implementation. Instead of hard-coded values scattered through the product, components reference named tokens, so a single change moves the whole system consistently. The values below are the real token layer already driving this site — a starting point for the fuller mapping.
+                      Tokens are the contract between design intent and implementation. Instead of
+                      hard-coded values scattered through the product, components reference named
+                      tokens, so a single change moves the whole system consistently. The values
+                      below are the real token layer already driving this site — a starting point
+                      for the fuller mapping.
                     </p>
                   }
                 />
@@ -230,7 +262,9 @@ const DesignSystemCase = () => (
                           <tbody>
                             {TOKEN_ROWS.map((row) => (
                               <tr key={row.token}>
-                                <td><code>{row.token}</code></td>
+                                <td>
+                                  <code>{row.token}</code>
+                                </td>
                                 <td>{row.value}</td>
                                 <td>{row.role}</td>
                               </tr>
@@ -243,7 +277,7 @@ const DesignSystemCase = () => (
                 />
                 <Row
                   content={
-                    <p className={'caption ' + pStyle}>
+                    <p className={"caption " + pStyle}>
                       Live token values from components/design-system/tokens.js
                     </p>
                   }
@@ -252,9 +286,9 @@ const DesignSystemCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Full token table'}
+                      title={"Full token table"}
                       prompt={
-                        'Insert the complete token reference: primitive tokens, semantic aliases, and their mapping to components. Show at least one worked example of a token change propagating through the system.'
+                        "Insert the complete token reference: primitive tokens, semantic aliases, and their mapping to components. Show at least one worked example of a token change propagating through the system."
                       }
                     />
                   }
@@ -264,13 +298,16 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'States'}
+            title={"States"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Consistency breaks most often in the states nobody screenshots: hover, focus, active, disabled, loading, error, and empty. A component is only finished when every state is defined, tokenized, and documented — so the built version cannot quietly omit the ones that matter for usability and accessibility.
+                      Consistency breaks most often in the states nobody screenshots: hover, focus,
+                      active, disabled, loading, error, and empty. A component is only finished when
+                      every state is defined, tokenized, and documented — so the built version
+                      cannot quietly omit the ones that matter for usability and accessibility.
                     </p>
                   }
                 />
@@ -278,9 +315,9 @@ const DesignSystemCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'State coverage'}
+                      title={"State coverage"}
                       prompt={
-                        'Insert a full state gallery for a key component: default, hover, focus-visible, active, disabled, loading, error, and empty — each mapped to its tokens and documented behavior.'
+                        "Insert a full state gallery for a key component: default, hover, focus-visible, active, disabled, loading, error, and empty — each mapped to its tokens and documented behavior."
                       }
                     />
                   }
@@ -290,20 +327,26 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'Accessibility'}
+            title={"Accessibility"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Accessibility is a system property, not a per-screen fix. Building it into components — dependable contrast, visible focus, meaning that never relies on color alone, sensible semantics and keyboard behavior — means every team that uses the system inherits a strong baseline instead of rediscovering it. This mirrors the accessibility bias this portfolio already holds itself to.
+                      Accessibility is a system property, not a per-screen fix. Building it into
+                      components — dependable contrast, visible focus, meaning that never relies on
+                      color alone, sensible semantics and keyboard behavior — means every team that
+                      uses the system inherits a strong baseline instead of rediscovering it. This
+                      mirrors the accessibility bias this portfolio already holds itself to.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      Specific accessibility decisions — contrast targets, focus treatment, keyboard patterns, and how they were verified — go here with the checks that back them, not as generic claims.
+                      Specific accessibility decisions — contrast targets, focus treatment, keyboard
+                      patterns, and how they were verified — go here with the checks that back them,
+                      not as generic claims.
                     </TbdNote>
                   }
                 />
@@ -312,13 +355,16 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'Documentation'}
+            title={"Documentation"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Documentation is what turns a component library into a system other people can use without asking. Good docs explain not just how a component looks but when to use it, how it behaves, and where its edges are. Without that surface, consistency depends on memory and does not survive new contributors.
+                      Documentation is what turns a component library into a system other people can
+                      use without asking. Good docs explain not just how a component looks but when
+                      to use it, how it behaves, and where its edges are. Without that surface,
+                      consistency depends on memory and does not survive new contributors.
                     </p>
                   }
                 />
@@ -326,9 +372,9 @@ const DesignSystemCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Storybook / documentation'}
+                      title={"Storybook / documentation"}
                       prompt={
-                        'Insert Storybook stories or documentation pages: usage guidance, props/controls, do and don’t examples, and live component states. Show the docs as the working reference, not a static spec.'
+                        "Insert Storybook stories or documentation pages: usage guidance, props/controls, do and don’t examples, and live component states. Show the docs as the working reference, not a static spec."
                       }
                     />
                   }
@@ -338,20 +384,26 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'Developer handoff'}
+            title={"Developer handoff"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Handoff is where design systems succeed or quietly fail. The goal is a tight loop where design intent, tokens, and code share one vocabulary, so engineers implement from the system rather than re-interpreting screenshots. When the token names in design match the token names in code, drift has far fewer places to enter.
+                      Handoff is where design systems succeed or quietly fail. The goal is a tight
+                      loop where design intent, tokens, and code share one vocabulary, so engineers
+                      implement from the system rather than re-interpreting screenshots. When the
+                      token names in design match the token names in code, drift has far fewer
+                      places to enter.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      The concrete handoff mechanics — shared token naming, review process, and how design and engineering stayed in sync — will be documented with real examples from the working process.
+                      The concrete handoff mechanics — shared token naming, review process, and how
+                      design and engineering stayed in sync — will be documented with real examples
+                      from the working process.
                     </TbdNote>
                   }
                 />
@@ -360,13 +412,16 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'QA checklist'}
+            title={"QA checklist"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Implementation QA is the step that keeps the built product honest to the system. A repeatable checklist — token usage, state coverage, accessibility, responsive behavior, and edge cases — turns consistency from an aspiration into something that is actually verified before it ships.
+                      Implementation QA is the step that keeps the built product honest to the
+                      system. A repeatable checklist — token usage, state coverage, accessibility,
+                      responsive behavior, and edge cases — turns consistency from an aspiration
+                      into something that is actually verified before it ships.
                     </p>
                   }
                 />
@@ -374,9 +429,9 @@ const DesignSystemCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'QA checklist'}
+                      title={"QA checklist"}
                       prompt={
-                        'Insert the real implementation-QA checklist used to sign off components: token usage, every interaction state, contrast and focus, responsive breakpoints, and content edge cases — with an example of a caught drift.'
+                        "Insert the real implementation-QA checklist used to sign off components: token usage, every interaction state, contrast and focus, responsive breakpoints, and content edge cases — with an example of a caught drift."
                       }
                     />
                   }
@@ -386,27 +441,35 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'Outcomes & proxy evidence'}
+            title={"Outcomes & proxy evidence"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Where hard metrics exist, they belong here. Where they do not, honest proxy evidence carries the case: a working token layer, documented components, a QA checklist that catches real drift, and consistency that holds across screens are all verifiable signals of infrastructure quality — without inventing adoption numbers or shipped claims that are not yet documented.
+                      Where hard metrics exist, they belong here. Where they do not, honest proxy
+                      evidence carries the case: a working token layer, documented components, a QA
+                      checklist that catches real drift, and consistency that holds across screens
+                      are all verifiable signals of infrastructure quality — without inventing
+                      adoption numbers or shipped claims that are not yet documented.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <p className={pStyle}>
-                      One honest proxy is already live: the token layer in this portfolio drives its shadows, radii, and accents from a single source, so the same discipline this case argues for is visible in the site presenting it.
+                      One honest proxy is already live: the token layer in this portfolio drives its
+                      shadows, radii, and accents from a single source, so the same discipline this
+                      case argues for is visible in the site presenting it.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      Measured outcomes (adoption, defect reduction, delivery speed) or qualitative evidence (contributor feedback, review notes) will be added only where they are real and attributable.
+                      Measured outcomes (adoption, defect reduction, delivery speed) or qualitative
+                      evidence (contributor feedback, review notes) will be added only where they
+                      are real and attributable.
                     </TbdNote>
                   }
                 />
@@ -415,20 +478,26 @@ const DesignSystemCase = () => (
           />
 
           <ProjectSection
-            title={'Reflection'}
+            title={"Reflection"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      The lesson that keeps repeating in this work: a design system is judged less by how its components look and more by how well the product holds together once many people are building on it. Components and tokens are the artifact; the documentation, handoff, and QA around them are the infrastructure that makes consistency survive contact with a growing team.
+                      The lesson that keeps repeating in this work: a design system is judged less
+                      by how its components look and more by how well the product holds together
+                      once many people are building on it. Components and tokens are the artifact;
+                      the documentation, handoff, and QA around them are the infrastructure that
+                      makes consistency survive contact with a growing team.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      A specific, honest reflection tied to the real project — what worked, what was hard, and what would change next time — will replace this placeholder once the case is populated.
+                      A specific, honest reflection tied to the real project — what worked, what was
+                      hard, and what would change next time — will replace this placeholder once the
+                      case is populated.
                     </TbdNote>
                   }
                 />

--- a/pages/direction-setting.js
+++ b/pages/direction-setting.js
@@ -1,15 +1,12 @@
-import React from 'react';
+import React from "react";
 
-import CaseStudyMeta from '../components/CaseStudyMeta';
-import ProjectPage from '../components/ProjectPage';
-import ProjectSection from '../components/ProjectSection';
-import Row from '../components/Row';
-import {
-  ArtifactPlaceholder,
-  TbdNote,
-} from '../components/design-system/CasePlaceholders';
+import CaseStudyMeta from "../components/CaseStudyMeta";
+import ProjectPage from "../components/ProjectPage";
+import ProjectSection from "../components/ProjectSection";
+import Row from "../components/Row";
+import { ArtifactPlaceholder, TbdNote } from "../components/design-system/CasePlaceholders";
 
-import placeholderTexture from '../static/media/pohja.svg';
+import placeholderTexture from "../static/media/pohja.svg";
 
 // NOTE: This case is intentionally kept out of the Projects manifest
 // (components/Projects.js) and the primary nav. It is a publish-safe shell
@@ -33,58 +30,58 @@ import placeholderTexture from '../static/media/pohja.svg';
 //    that survived contact with engineering.
 
 const pStyle =
-  'col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6';
+  "col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6";
 
 const DirectionSettingCase = () => (
   <div className="DirectionSettingCase">
     <ProjectPage
-      projectName={'Direction Setting'}
-      title={'From Ambiguity to Shared Direction'}
+      projectName={"Direction Setting"}
+      title={"From Ambiguity to Shared Direction"}
       hero={placeholderTexture}
       heroAlt={
-        'Placeholder texture for the direction-setting case — anonymized workshop and mapping artwork pending.'
+        "Placeholder texture for the direction-setting case — anonymized workshop and mapping artwork pending."
       }
-      eyebrow={'Methods case shell — in progress'}
-      navbarColor={'green'}
+      eyebrow={"Methods case shell — in progress"}
+      navbarColor={"green"}
       showNextProject={false}
       description={
-        'How a project that starts as a vague brief, competing stakeholder agendas, and untested assumptions becomes a direction the whole team can commit to — the interviews, mapping, facilitation, and decision-keeping that get it there.'
+        "How a project that starts as a vague brief, competing stakeholder agendas, and untested assumptions becomes a direction the whole team can commit to — the interviews, mapping, facilitation, and decision-keeping that get it there."
       }
       content={
         <span>
           <CaseStudyMeta
-            status={'Methods case shell — in progress'}
+            status={"Methods case shell — in progress"}
             summary={
-              'A capability case about the least visible design work: turning ambiguity into direction. Not one project — a working method, shown through the artifacts it produces: interview synthesis, current-state journeys, assumption matrices, risk maps, opportunity rankings, and decision logs.'
+              "A capability case about the least visible design work: turning ambiguity into direction. Not one project — a working method, shown through the artifacts it produces: interview synthesis, current-state journeys, assumption matrices, risk maps, opportunity rankings, and decision logs."
             }
             note={
-              'The method described here is how Harri actually works; the section framing is real. The artifacts are pending and will be recreated from real projects with neutral labels — no client names, participant details, or invented outcomes. Until an artifact is attached, its slot says so on the page.'
+              "The method described here is how Harri actually works; the section framing is real. The artifacts are pending and will be recreated from real projects with neutral labels — no client names, participant details, or invented outcomes. Until an artifact is attached, its slot says so on the page."
             }
             fields={{
               myRole:
-                'Designer driving the ambiguous front end of projects: stakeholder interviews, research, assumption and risk mapping, workshop facilitation, and keeping the record of decisions as direction forms.',
-              team: 'This work is never solo by definition — it happens with product managers, engineers, and business stakeholders. Specific collaborators are documented per project, not inflated here.',
+                "Designer driving the ambiguous front end of projects: stakeholder interviews, research, assumption and risk mapping, workshop facilitation, and keeping the record of decisions as direction forms.",
+              team: "This work is never solo by definition — it happens with product managers, engineers, and business stakeholders. Specific collaborators are documented per project, not inflated here.",
               context:
-                'The phase where a project has momentum but no shape: a goal everyone phrases differently, assumptions nobody has written down, and three functions each optimizing for their own picture of success.',
+                "The phase where a project has momentum but no shape: a goal everyone phrases differently, assumptions nobody has written down, and three functions each optimizing for their own picture of success.",
               problem:
-                'Problem type: disagreement that looks like alignment. Teams rarely lack opinions — they lack a shared, testable picture of the problem. The design work is building that picture and getting real commitment to a direction, including from the people who argued against it.',
+                "Problem type: disagreement that looks like alignment. Teams rarely lack opinions — they lack a shared, testable picture of the problem. The design work is building that picture and getting real commitment to a direction, including from the people who argued against it.",
             }}
           />
 
           <ProjectSection
-            title={'What ambiguity actually looks like'}
+            title={"What ambiguity actually looks like"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Ambiguity in a real project is rarely an empty page. It is a PM with a
-                      roadmap commitment, an engineering lead who has quietly already chosen an
-                      architecture, and a business owner whose success metric nobody else has
-                      seen — all using the same words to mean different things. The kickoff
-                      feels aligned because nothing concrete enough to disagree about has been
-                      said yet. The job is to surface the disagreement early, on paper, where
-                      it is cheap — instead of in the backlog six weeks later, where it is not.
+                      Ambiguity in a real project is rarely an empty page. It is a PM with a roadmap
+                      commitment, an engineering lead who has quietly already chosen an
+                      architecture, and a business owner whose success metric nobody else has seen —
+                      all using the same words to mean different things. The kickoff feels aligned
+                      because nothing concrete enough to disagree about has been said yet. The job
+                      is to surface the disagreement early, on paper, where it is cheap — instead of
+                      in the backlog six weeks later, where it is not.
                     </p>
                   }
                 />
@@ -93,20 +90,20 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Stakeholder interviews'}
+            title={"Stakeholder interviews"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Direction work starts one conversation at a time, before any group
-                      session. Individual interviews with the PM, engineers, and business
-                      stakeholders answer three things: what does success look like from your
-                      seat, what do you believe about the users and the problem, and what are
-                      you worried nobody is saying out loud. People say things one-on-one that
-                      they will not volunteer in a workshop — especially the worries. The
-                      output is not notes; it is a map of where the pictures of success
-                      genuinely differ, which becomes the agenda for everything that follows.
+                      Direction work starts one conversation at a time, before any group session.
+                      Individual interviews with the PM, engineers, and business stakeholders answer
+                      three things: what does success look like from your seat, what do you believe
+                      about the users and the problem, and what are you worried nobody is saying out
+                      loud. People say things one-on-one that they will not volunteer in a workshop
+                      — especially the worries. The output is not notes; it is a map of where the
+                      pictures of success genuinely differ, which becomes the agenda for everything
+                      that follows.
                     </p>
                   }
                 />
@@ -114,8 +111,8 @@ const DirectionSettingCase = () => (
                   content={
                     <TbdNote className={pStyle}>
                       An anonymized interview-synthesis example — how conflicting stakeholder
-                      framings from a real project were captured and clustered, with neutral
-                      role labels — will be attached here.
+                      framings from a real project were captured and clustered, with neutral role
+                      labels — will be attached here.
                     </TbdNote>
                   }
                 />
@@ -124,20 +121,20 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Current-state journey'}
+            title={"Current-state journey"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Before anyone debates the future, the present has to be on one page.
-                      A current-state journey — assembled from the interviews and from
-                      watching the work happen — shows what users and the organization
-                      actually do today, including the workarounds nobody put in the brief.
-                      This artifact does quiet political work: it moves the argument from
-                      &ldquo;my opinion versus yours&rdquo; to &ldquo;here is the wall, point
-                      at the part you disagree with.&rdquo; Most alignment problems shrink
-                      once everyone is criticizing the same picture.
+                      Before anyone debates the future, the present has to be on one page. A
+                      current-state journey — assembled from the interviews and from watching the
+                      work happen — shows what users and the organization actually do today,
+                      including the workarounds nobody put in the brief. This artifact does quiet
+                      political work: it moves the argument from &ldquo;my opinion versus
+                      yours&rdquo; to &ldquo;here is the wall, point at the part you disagree
+                      with.&rdquo; Most alignment problems shrink once everyone is criticizing the
+                      same picture.
                     </p>
                   }
                 />
@@ -145,9 +142,9 @@ const DirectionSettingCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Current-state journey'}
+                      title={"Current-state journey"}
                       prompt={
-                        'Insert a recreated current-state journey from a real project: stages, actions, tools, and pain points with neutral labels. Annotate one place where the mapped reality contradicted what stakeholders believed in the kickoff.'
+                        "Insert a recreated current-state journey from a real project: stages, actions, tools, and pain points with neutral labels. Annotate one place where the mapped reality contradicted what stakeholders believed in the kickoff."
                       }
                     />
                   }
@@ -157,29 +154,28 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'User research'}
+            title={"User research"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Stakeholder views are hypotheses, not evidence. Research in this phase
-                      is scoped tightly to the disagreements that matter: user interviews,
-                      observation, or lightweight testing aimed at the specific questions the
-                      team cannot settle from the inside. The standard is honest, not heroic —
-                      a handful of well-chosen conversations that kill a wrong assumption
-                      beats a research theater program nobody reads. Findings go back to the
-                      team attributed to evidence, not to the designer, which is what lets
-                      them override seniority in the room.
+                      Stakeholder views are hypotheses, not evidence. Research in this phase is
+                      scoped tightly to the disagreements that matter: user interviews, observation,
+                      or lightweight testing aimed at the specific questions the team cannot settle
+                      from the inside. The standard is honest, not heroic — a handful of well-chosen
+                      conversations that kill a wrong assumption beats a research theater program
+                      nobody reads. Findings go back to the team attributed to evidence, not to the
+                      designer, which is what lets them override seniority in the room.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      A concrete example — a research question a team could not settle
-                      internally, how it was studied, and which assumption the findings
-                      overturned — will be documented here, anonymized.
+                      A concrete example — a research question a team could not settle internally,
+                      how it was studied, and which assumption the findings overturned — will be
+                      documented here, anonymized.
                     </TbdNote>
                   }
                 />
@@ -188,21 +184,20 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Assumption mapping'}
+            title={"Assumption mapping"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
                       Every plan stands on assumptions; the dangerous ones are unwritten. The
-                      team&rsquo;s beliefs — about users, feasibility, and the business — get
-                      pulled out of heads and onto a matrix: how important is this if wrong,
-                      and how much evidence do we actually have. The top-right corner
-                      (critical, unproven) is the risk register nobody knew they had, and it
-                      turns &ldquo;we should do more research&rdquo; from a stalling tactic
-                      into a targeted list. Engineers tend to like this artifact most: it is
-                      the first time the project&rsquo;s uncertainty is stated in a form you
-                      can act on.
+                      team&rsquo;s beliefs — about users, feasibility, and the business — get pulled
+                      out of heads and onto a matrix: how important is this if wrong, and how much
+                      evidence do we actually have. The top-right corner (critical, unproven) is the
+                      risk register nobody knew they had, and it turns &ldquo;we should do more
+                      research&rdquo; from a stalling tactic into a targeted list. Engineers tend to
+                      like this artifact most: it is the first time the project&rsquo;s uncertainty
+                      is stated in a form you can act on.
                     </p>
                   }
                 />
@@ -210,9 +205,9 @@ const DirectionSettingCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Assumption matrix'}
+                      title={"Assumption matrix"}
                       prompt={
-                        'Insert a recreated assumption matrix (importance × evidence) from a real project, neutral labels only. Highlight the critical-but-unproven quadrant and note which assumptions were tested versus consciously accepted as risks.'
+                        "Insert a recreated assumption matrix (importance × evidence) from a real project, neutral labels only. Highlight the critical-but-unproven quadrant and note which assumptions were tested versus consciously accepted as risks."
                       }
                     />
                   }
@@ -222,7 +217,7 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Risk map'}
+            title={"Risk map"}
             content={
               <span>
                 <Row
@@ -230,12 +225,11 @@ const DirectionSettingCase = () => (
                     <p className={pStyle}>
                       Assumptions are one kind of risk; delivery has others — dependencies,
                       capability gaps, deadlines that were promised before the problem was
-                      understood. Mapping risks with the team, and being explicit about which
-                      are design risks, which are engineering risks, and which are business
-                      risks, does two things: it stops any one function from silently carrying
-                      risk the others created, and it gives the eventual direction its honest
-                      price tag. A direction chosen without a risk map is a preference, not a
-                      decision.
+                      understood. Mapping risks with the team, and being explicit about which are
+                      design risks, which are engineering risks, and which are business risks, does
+                      two things: it stops any one function from silently carrying risk the others
+                      created, and it gives the eventual direction its honest price tag. A direction
+                      chosen without a risk map is a preference, not a decision.
                     </p>
                   }
                 />
@@ -243,9 +237,9 @@ const DirectionSettingCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Risk map'}
+                      title={"Risk map"}
                       prompt={
-                        'Insert a recreated risk map from a real project: risks plotted by likelihood and impact, tagged by owner (design / engineering / business), neutral labels. Annotate one risk that changed the chosen direction.'
+                        "Insert a recreated risk map from a real project: risks plotted by likelihood and impact, tagged by owner (design / engineering / business), neutral labels. Annotate one risk that changed the chosen direction."
                       }
                     />
                   }
@@ -255,41 +249,40 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Workshop facilitation'}
+            title={"Workshop facilitation"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Workshops are where this work is easiest to fake and easiest to judge.
-                      The test of a session is not energy or wall coverage — it is whether
-                      something is decided that was not decided before, and whether the people
-                      who lost the argument still commit to the outcome. That means designing
-                      the session backwards from its decision, doing the divergent thinking
-                      asynchronously where possible, and spending shared room time on the
-                      genuinely contested parts. It also means naming disagreement instead of
-                      averaging it: two strong options with a criteria-based choice beat a
-                      compromise nobody believes in.
+                      Workshops are where this work is easiest to fake and easiest to judge. The
+                      test of a session is not energy or wall coverage — it is whether something is
+                      decided that was not decided before, and whether the people who lost the
+                      argument still commit to the outcome. That means designing the session
+                      backwards from its decision, doing the divergent thinking asynchronously where
+                      possible, and spending shared room time on the genuinely contested parts. It
+                      also means naming disagreement instead of averaging it: two strong options
+                      with a criteria-based choice beat a compromise nobody believes in.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <p className={pStyle}>
-                      Facilitating means being neutral about people and opinionated about
-                      process. The designer&rsquo;s own design preferences enter as one voice
-                      among the options — labelled as such — because a facilitator who
-                      smuggles their preferred outcome through the format loses the room
-                      permanently, and deserves to.
+                      Facilitating means being neutral about people and opinionated about process.
+                      The designer&rsquo;s own design preferences enter as one voice among the
+                      options — labelled as such — because a facilitator who smuggles their
+                      preferred outcome through the format loses the room permanently, and deserves
+                      to.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      A real session design — its intended decision, the agenda built
-                      backwards from it, and what the session actually produced — will be
-                      documented here with anonymized materials.
+                      A real session design — its intended decision, the agenda built backwards from
+                      it, and what the session actually produced — will be documented here with
+                      anonymized materials.
                     </TbdNote>
                   }
                 />
@@ -298,21 +291,20 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Prioritization'}
+            title={"Prioritization"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
                       With the problem mapped and the risks named, opportunities get ranked —
-                      against criteria the team agreed on before seeing the list, because
-                      criteria chosen afterwards are just rationalization. User value,
-                      business value, effort, and risk each have a stakeholder who naturally
-                      champions them; the ranking conversation is where PM, engineering, and
-                      business trade honestly instead of each keeping a private priority
-                      order. The output is not just a sequence — it is a shared understanding
-                      of why the second thing is second, which is what keeps the roadmap
-                      stable when pressure arrives.
+                      against criteria the team agreed on before seeing the list, because criteria
+                      chosen afterwards are just rationalization. User value, business value,
+                      effort, and risk each have a stakeholder who naturally champions them; the
+                      ranking conversation is where PM, engineering, and business trade honestly
+                      instead of each keeping a private priority order. The output is not just a
+                      sequence — it is a shared understanding of why the second thing is second,
+                      which is what keeps the roadmap stable when pressure arrives.
                     </p>
                   }
                 />
@@ -320,9 +312,9 @@ const DirectionSettingCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Opportunity ranking'}
+                      title={"Opportunity ranking"}
                       prompt={
-                        'Insert a recreated opportunity ranking from a real project: options scored against the agreed criteria, neutral labels. Annotate one ranking that surprised a stakeholder and how the criteria settled it.'
+                        "Insert a recreated opportunity ranking from a real project: options scored against the agreed criteria, neutral labels. Annotate one ranking that surprised a stakeholder and how the criteria settled it."
                       }
                     />
                   }
@@ -332,29 +324,29 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Trade-offs & shared principles'}
+            title={"Trade-offs & shared principles"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Direction means giving things up, and the giving-up has to be said out
-                      loud: what this direction will not do, which stakeholder&rsquo;s
-                      preferred option was declined and why, what the team is accepting as a
-                      known cost. Writing trade-offs down at decision time is what prevents
-                      them from being re-litigated as betrayals later. The durable ones get
-                      promoted into shared principles — short, argument-settling statements
-                      the team wrote together — so the hundredth small decision doesn&rsquo;t
-                      need another meeting, because the principle already answers it.
+                      Direction means giving things up, and the giving-up has to be said out loud:
+                      what this direction will not do, which stakeholder&rsquo;s preferred option
+                      was declined and why, what the team is accepting as a known cost. Writing
+                      trade-offs down at decision time is what prevents them from being re-litigated
+                      as betrayals later. The durable ones get promoted into shared principles —
+                      short, argument-settling statements the team wrote together — so the hundredth
+                      small decision doesn&rsquo;t need another meeting, because the principle
+                      already answers it.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      An example set of project principles from real work — what each one
-                      settled, and a decision that was resolved by citing one instead of
-                      escalating — will be attached here, anonymized.
+                      An example set of project principles from real work — what each one settled,
+                      and a decision that was resolved by citing one instead of escalating — will be
+                      attached here, anonymized.
                     </TbdNote>
                   }
                 />
@@ -363,20 +355,19 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Decision log'}
+            title={"Decision log"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Alignment decays without a record. A decision log — the call, the date,
-                      the reasoning, the trade-off accepted, who was in the room — is the
-                      cheapest alignment tool there is. It gives new joiners the
-                      &ldquo;why&rdquo; without archaeology, protects decisions from being
-                      quietly reversed by whoever edits the document last, and makes revisiting
-                      a call an explicit act with new information rather than an accident. It
-                      also keeps the facilitator honest: if the log can&rsquo;t say why, the
-                      decision wasn&rsquo;t really made.
+                      Alignment decays without a record. A decision log — the call, the date, the
+                      reasoning, the trade-off accepted, who was in the room — is the cheapest
+                      alignment tool there is. It gives new joiners the &ldquo;why&rdquo; without
+                      archaeology, protects decisions from being quietly reversed by whoever edits
+                      the document last, and makes revisiting a call an explicit act with new
+                      information rather than an accident. It also keeps the facilitator honest: if
+                      the log can&rsquo;t say why, the decision wasn&rsquo;t really made.
                     </p>
                   }
                 />
@@ -384,9 +375,9 @@ const DirectionSettingCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Decision log'}
+                      title={"Decision log"}
                       prompt={
-                        'Insert recreated decision-log entries from a real project: decision, date, reasoning, trade-off, participants — neutral labels. Include one entry where the log prevented a settled decision from being re-litigated.'
+                        "Insert recreated decision-log entries from a real project: decision, date, reasoning, trade-off, participants — neutral labels. Include one entry where the log prevented a settled decision from being re-litigated."
                       }
                     />
                   }
@@ -396,31 +387,30 @@ const DirectionSettingCase = () => (
           />
 
           <ProjectSection
-            title={'Direction, held'}
+            title={"Direction, held"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      The outcome of this work is not a deck — it is a team that can act
-                      without meeting: a PM who can defend the roadmap upward because the
-                      reasoning is written down, engineers building against assumptions that
-                      were tested instead of inherited, and business stakeholders who know
-                      which trade-offs they accepted. Where hard metrics from this work exist
-                      and can be shared, they will be shown; where they cannot, the proxy
-                      evidence is the artifacts themselves and the decisions they carried.
-                      That is a verifiable claim about the method — nothing here will be
-                      decorated with invented outcomes.
+                      The outcome of this work is not a deck — it is a team that can act without
+                      meeting: a PM who can defend the roadmap upward because the reasoning is
+                      written down, engineers building against assumptions that were tested instead
+                      of inherited, and business stakeholders who know which trade-offs they
+                      accepted. Where hard metrics from this work exist and can be shared, they will
+                      be shown; where they cannot, the proxy evidence is the artifacts themselves
+                      and the decisions they carried. That is a verifiable claim about the method —
+                      nothing here will be decorated with invented outcomes.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      Documented outcomes per project — directions that held through
-                      delivery, disagreements resolved without escalation, and an honest note
-                      on the times a chosen direction had to change and what the method missed
-                      — will be added here as evidence is cleared.
+                      Documented outcomes per project — directions that held through delivery,
+                      disagreements resolved without escalation, and an honest note on the times a
+                      chosen direction had to change and what the method missed — will be added here
+                      as evidence is cleared.
                     </TbdNote>
                   }
                 />

--- a/pages/operations-platform.js
+++ b/pages/operations-platform.js
@@ -1,15 +1,12 @@
-import React from 'react';
+import React from "react";
 
-import CaseStudyMeta from '../components/CaseStudyMeta';
-import ProjectPage from '../components/ProjectPage';
-import ProjectSection from '../components/ProjectSection';
-import Row from '../components/Row';
-import {
-  ArtifactPlaceholder,
-  TbdNote,
-} from '../components/design-system/CasePlaceholders';
+import CaseStudyMeta from "../components/CaseStudyMeta";
+import ProjectPage from "../components/ProjectPage";
+import ProjectSection from "../components/ProjectSection";
+import Row from "../components/Row";
+import { ArtifactPlaceholder, TbdNote } from "../components/design-system/CasePlaceholders";
 
-import placeholderTexture from '../static/media/pohja.svg';
+import placeholderTexture from "../static/media/pohja.svg";
 
 // NOTE: This case is intentionally kept out of the Projects manifest
 // (components/Projects.js) and the primary nav. It is a publish-safe shell
@@ -37,52 +34,57 @@ import placeholderTexture from '../static/media/pohja.svg';
 //    leave it in a TbdNote. The case must stay publishable at every stage.
 
 const pStyle =
-  'col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6';
+  "col-xs-12 col-sm-12 col-md-offset-1 col-md-10 col-lg-offset-2dot5 col-lg-7 col-xl-offset-3 col-xl-6";
 
 const OperationsPlatformCase = () => (
   <div className="OperationsPlatformCase">
     <ProjectPage
-      projectName={'Operations Platform'}
-      title={'From Fragmented Operational Workflows to a Scalable Product'}
+      projectName={"Operations Platform"}
+      title={"From Fragmented Operational Workflows to a Scalable Product"}
       hero={placeholderTexture}
       heroAlt={
-        'Placeholder texture for the operations platform case — anonymized workflow artwork pending.'
+        "Placeholder texture for the operations platform case — anonymized workflow artwork pending."
       }
-      eyebrow={'Case shell — in progress'}
-      navbarColor={'blue'}
+      eyebrow={"Case shell — in progress"}
+      navbarColor={"blue"}
       showNextProject={false}
       description={
-        'How a domain full of manual handoffs, tribal knowledge, and parallel tools becomes one coherent product experience — the mapping, modeling, and prioritization work that makes complex operations designable.'
+        "How a domain full of manual handoffs, tribal knowledge, and parallel tools becomes one coherent product experience — the mapping, modeling, and prioritization work that makes complex operations designable."
       }
       content={
         <span>
           <CaseStudyMeta
-            status={'Case shell — in progress'}
+            status={"Case shell — in progress"}
             summary={
-              'A capability case about designing for operational complexity: many roles, uneven permissions, workflows that live partly in tools and partly in people’s heads. The design work is making that complexity legible first, then deciding what the product should absorb and in what order.'
+              "A capability case about designing for operational complexity: many roles, uneven permissions, workflows that live partly in tools and partly in people’s heads. The design work is making that complexity legible first, then deciding what the product should absorb and in what order."
             }
             note={
-              'This page is a structured shell for anonymized client work. The framing and section scaffolding are real; diagrams, UI, and evidence are marked as pending and will be recreated with neutral labels — no client names, internal system names, real data, or invented metrics. Nothing here claims a shipped outcome that is not yet documented.'
+              "This page is a structured shell for anonymized client work. The framing and section scaffolding are real; diagrams, UI, and evidence are marked as pending and will be recreated with neutral labels — no client names, internal system names, real data, or invented metrics. Nothing here claims a shipped outcome that is not yet documented."
             }
             fields={{
               myRole:
-                'End-to-end product design in a complex operational domain: domain research, workflow and stakeholder mapping, concept modeling, UI design, and implementation support through to QA.',
-              team: 'To be completed with real evidence — collaborators, engineering partners, and how ownership was split are documented per project, not inflated here.',
+                "End-to-end product design in a complex operational domain: domain research, workflow and stakeholder mapping, concept modeling, UI design, and implementation support through to QA.",
+              team: "To be completed with real evidence — collaborators, engineering partners, and how ownership was split are documented per project, not inflated here.",
               context:
-                'An operational domain where daily work runs through fragmented tools and manual handoffs, and the goal is a single product experience that can scale past the people who currently hold it together.',
+                "An operational domain where daily work runs through fragmented tools and manual handoffs, and the goal is a single product experience that can scale past the people who currently hold it together.",
               problem:
-                'Problem type: the workflow exists but is not a product — it is distributed across tools, spreadsheets, and individual knowledge. The design challenge is understanding it faithfully before changing it.',
+                "Problem type: the workflow exists but is not a product — it is distributed across tools, spreadsheets, and individual knowledge. The design challenge is understanding it faithfully before changing it.",
             }}
           />
 
           <ProjectSection
-            title={'Domain complexity'}
+            title={"Domain complexity"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Operational domains resist quick design because the complexity is real, not accidental: regulations, exceptions, regional differences, and years of accumulated practice all have reasons. The first design task is not simplification — it is building an accurate picture of why the work is shaped the way it is, so the product simplifies the right things and preserves the constraints that must hold.
+                      Operational domains resist quick design because the complexity is real, not
+                      accidental: regulations, exceptions, regional differences, and years of
+                      accumulated practice all have reasons. The first design task is not
+                      simplification — it is building an accurate picture of why the work is shaped
+                      the way it is, so the product simplifies the right things and preserves the
+                      constraints that must hold.
                     </p>
                   }
                 />
@@ -90,9 +92,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Domain overview'}
+                      title={"Domain overview"}
                       prompt={
-                        'TODO: Insert an anonymized overview of the domain — the kinds of entities, rules, and exceptions that make it complex. Recreate as a neutral diagram; describe the shape of the complexity, never the client or their internal system names.'
+                        "TODO: Insert an anonymized overview of the domain — the kinds of entities, rules, and exceptions that make it complex. Recreate as a neutral diagram; describe the shape of the complexity, never the client or their internal system names."
                       }
                     />
                   }
@@ -102,13 +104,18 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Stakeholder map'}
+            title={"Stakeholder map"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      In operational products the user is rarely one person. Work passes between people who initiate, people who verify, people who approve, and people who answer for the outcome — and their incentives do not automatically align. Mapping who touches the workflow, what each party needs from it, and where their interests pull in different directions is what keeps later design decisions from optimizing one seat at another’s expense.
+                      In operational products the user is rarely one person. Work passes between
+                      people who initiate, people who verify, people who approve, and people who
+                      answer for the outcome — and their incentives do not automatically align.
+                      Mapping who touches the workflow, what each party needs from it, and where
+                      their interests pull in different directions is what keeps later design
+                      decisions from optimizing one seat at another’s expense.
                     </p>
                   }
                 />
@@ -116,9 +123,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Stakeholder map'}
+                      title={"Stakeholder map"}
                       prompt={
-                        'TODO: Insert an anonymized stakeholder map with neutral role labels (e.g. Coordinator, Reviewer, Field Operator, Management). Show information flow and tension points between roles — not org charts or real titles that could identify the client.'
+                        "TODO: Insert an anonymized stakeholder map with neutral role labels (e.g. Coordinator, Reviewer, Field Operator, Management). Show information flow and tension points between roles — not org charts or real titles that could identify the client."
                       }
                     />
                   }
@@ -128,13 +135,17 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'User roles & permissions'}
+            title={"User roles & permissions"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Roles and permissions are where operational products differ most from consumer ones: what a person can see, edit, and approve is part of the workflow’s correctness, not an admin afterthought. Getting the role model right early shapes everything downstream — navigation, defaults, and which mistakes the product makes impossible rather than merely discouraged.
+                      Roles and permissions are where operational products differ most from consumer
+                      ones: what a person can see, edit, and approve is part of the workflow’s
+                      correctness, not an admin afterthought. Getting the role model right early
+                      shapes everything downstream — navigation, defaults, and which mistakes the
+                      product makes impossible rather than merely discouraged.
                     </p>
                   }
                 />
@@ -142,9 +153,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Role & permission model'}
+                      title={"Role & permission model"}
                       prompt={
-                        'TODO: Insert an anonymized role/permission matrix: roles as neutral labels, capabilities as rows (view, edit, approve, administer). Highlight the decisions — which permissions were deliberately separated and why.'
+                        "TODO: Insert an anonymized role/permission matrix: roles as neutral labels, capabilities as rows (view, edit, approve, administer). Highlight the decisions — which permissions were deliberately separated and why."
                       }
                     />
                   }
@@ -154,13 +165,17 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Current-state workflow'}
+            title={"Current-state workflow"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Before proposing anything, the existing workflow has to be documented as it actually runs — including the unofficial parts: the spreadsheet that bridges two systems, the phone call that resolves ambiguity, the person who remembers the exceptions. A current-state map that flatters the process is useless; the value is in capturing where the work really lives.
+                      Before proposing anything, the existing workflow has to be documented as it
+                      actually runs — including the unofficial parts: the spreadsheet that bridges
+                      two systems, the phone call that resolves ambiguity, the person who remembers
+                      the exceptions. A current-state map that flatters the process is useless; the
+                      value is in capturing where the work really lives.
                     </p>
                   }
                 />
@@ -168,9 +183,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Current-state workflow map'}
+                      title={"Current-state workflow map"}
                       prompt={
-                        'TODO: Insert a recreated end-to-end map of the current workflow: steps, tools, handoffs, and the manual or informal bridges between them. Neutral labels only; mark which steps lived outside any system.'
+                        "TODO: Insert a recreated end-to-end map of the current workflow: steps, tools, handoffs, and the manual or informal bridges between them. Neutral labels only; mark which steps lived outside any system."
                       }
                     />
                   }
@@ -180,13 +195,17 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Pain points'}
+            title={"Pain points"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Fragmented workflows fail in predictable ways: information re-entered between tools, status that exists only in someone’s inbox, handoffs that stall when a key person is away, and errors discovered far from where they were made. Naming the pain points precisely — and tracing each one to its structural cause — is what turns complaints into a design agenda.
+                      Fragmented workflows fail in predictable ways: information re-entered between
+                      tools, status that exists only in someone’s inbox, handoffs that stall when a
+                      key person is away, and errors discovered far from where they were made.
+                      Naming the pain points precisely — and tracing each one to its structural
+                      cause — is what turns complaints into a design agenda.
                     </p>
                   }
                 />
@@ -194,9 +213,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Pain point inventory'}
+                      title={"Pain point inventory"}
                       prompt={
-                        'TODO: Insert the anonymized pain-point inventory mapped onto the current-state workflow: where time was lost, where errors entered, where knowledge was person-dependent. Describe the failure pattern, not real incidents or data.'
+                        "TODO: Insert the anonymized pain-point inventory mapped onto the current-state workflow: where time was lost, where errors entered, where knowledge was person-dependent. Describe the failure pattern, not real incidents or data."
                       }
                     />
                   }
@@ -206,13 +225,17 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Decision points'}
+            title={"Decision points"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      A workflow is really a chain of decisions: who may proceed, what needs checking, when an exception escalates. Identifying every decision point — what information it needs, who is authorized to make it, and what happens on each branch — is the analysis that lets a product support the workflow instead of just digitizing its paperwork.
+                      A workflow is really a chain of decisions: who may proceed, what needs
+                      checking, when an exception escalates. Identifying every decision point — what
+                      information it needs, who is authorized to make it, and what happens on each
+                      branch — is the analysis that lets a product support the workflow instead of
+                      just digitizing its paperwork.
                     </p>
                   }
                 />
@@ -220,9 +243,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Decision point analysis'}
+                      title={"Decision point analysis"}
                       prompt={
-                        'TODO: Insert an anonymized breakdown of the workflow’s key decision points: inputs required, deciding role, branches, and escalation paths. Show at least one decision the product automated versus one it deliberately left with people, and why.'
+                        "TODO: Insert an anonymized breakdown of the workflow’s key decision points: inputs required, deciding role, branches, and escalation paths. Show at least one decision the product automated versus one it deliberately left with people, and why."
                       }
                     />
                   }
@@ -232,13 +255,18 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Concept model'}
+            title={"Concept model"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      The concept model is where scattered practice becomes a product: naming the core objects, their states, and their relationships so that every screen, permission, and notification hangs off the same skeleton. In operational domains this is the highest-leverage design artifact — if the model matches how practitioners actually think, the UI almost designs itself; if it doesn’t, no amount of interface polish compensates.
+                      The concept model is where scattered practice becomes a product: naming the
+                      core objects, their states, and their relationships so that every screen,
+                      permission, and notification hangs off the same skeleton. In operational
+                      domains this is the highest-leverage design artifact — if the model matches
+                      how practitioners actually think, the UI almost designs itself; if it doesn’t,
+                      no amount of interface polish compensates.
                     </p>
                   }
                 />
@@ -246,9 +274,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Concept model'}
+                      title={"Concept model"}
                       prompt={
-                        'TODO: Insert the anonymized concept model: core objects, their lifecycle states, and relationships. Annotate the naming decisions — where the product’s vocabulary followed practitioner language and where it deliberately diverged.'
+                        "TODO: Insert the anonymized concept model: core objects, their lifecycle states, and relationships. Annotate the naming decisions — where the product’s vocabulary followed practitioner language and where it deliberately diverged."
                       }
                     />
                   }
@@ -258,13 +286,17 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Prioritized journeys'}
+            title={"Prioritized journeys"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Everything cannot ship at once, and in operational products the sequencing is itself a design decision: the first journeys must be complete enough that people can move their real work over, or the old tools stay authoritative and the product becomes one more parallel system. Prioritization here means choosing end-to-end slices of the workflow, not features.
+                      Everything cannot ship at once, and in operational products the sequencing is
+                      itself a design decision: the first journeys must be complete enough that
+                      people can move their real work over, or the old tools stay authoritative and
+                      the product becomes one more parallel system. Prioritization here means
+                      choosing end-to-end slices of the workflow, not features.
                     </p>
                   }
                 />
@@ -272,9 +304,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Journey prioritization'}
+                      title={"Journey prioritization"}
                       prompt={
-                        'TODO: Insert the prioritized journey map: which end-to-end workflows shipped first and why, which were deferred, and what criteria drove the order (frequency, risk, dependency on other slices). Anonymized, with reasoning visible.'
+                        "TODO: Insert the prioritized journey map: which end-to-end workflows shipped first and why, which were deferred, and what criteria drove the order (frequency, risk, dependency on other slices). Anonymized, with reasoning visible."
                       }
                     />
                   }
@@ -284,13 +316,17 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Design & prototypes'}
+            title={"Design & prototypes"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      With the model and priorities set, the interface work is about making dense operational information scannable and the next required action obvious — for each role, at each state of the work. Prototypes earn their keep in this domain by being tested against real scenarios: the messy case, the exception, the handoff, not just the happy path.
+                      With the model and priorities set, the interface work is about making dense
+                      operational information scannable and the next required action obvious — for
+                      each role, at each state of the work. Prototypes earn their keep in this
+                      domain by being tested against real scenarios: the messy case, the exception,
+                      the handoff, not just the happy path.
                     </p>
                   }
                 />
@@ -298,9 +334,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Prototype walkthrough'}
+                      title={"Prototype walkthrough"}
                       prompt={
-                        'TODO: Insert recreated prototype screens or flows for one prioritized journey, with neutral data. Annotate what each iteration changed and what feedback drove it.'
+                        "TODO: Insert recreated prototype screens or flows for one prioritized journey, with neutral data. Annotate what each iteration changed and what feedback drove it."
                       }
                     />
                   }
@@ -309,9 +345,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'Final UI'}
+                      title={"Final UI"}
                       prompt={
-                        'TODO: Insert recreated final UI for the key screens, populated with placeholder data. Highlight the role-specific views and how the same underlying state renders differently per role.'
+                        "TODO: Insert recreated final UI for the key screens, populated with placeholder data. Highlight the role-specific views and how the same underlying state renders differently per role."
                       }
                     />
                   }
@@ -321,20 +357,26 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Implementation support'}
+            title={"Implementation support"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Operational products live or die in the details that emerge during build: edge cases the mapping missed, states nobody drew, performance constraints that reshape a screen. Staying close to engineering through implementation — answering questions at the speed of the sprint and adjusting the design when reality pushes back — is part of the design work, not what happens after it.
+                      Operational products live or die in the details that emerge during build: edge
+                      cases the mapping missed, states nobody drew, performance constraints that
+                      reshape a screen. Staying close to engineering through implementation —
+                      answering questions at the speed of the sprint and adjusting the design when
+                      reality pushes back — is part of the design work, not what happens after it.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      TODO: Concrete implementation-support practices from this project — how design questions were resolved during build, what changed from the specs and why — will be documented here with real examples, anonymized.
+                      TODO: Concrete implementation-support practices from this project — how design
+                      questions were resolved during build, what changed from the specs and why —
+                      will be documented here with real examples, anonymized.
                     </TbdNote>
                   }
                 />
@@ -343,13 +385,17 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'QA'}
+            title={"QA"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Design QA in an operational product means verifying the workflow, not just the pixels: does each role see what they should, do state transitions behave at every decision point, do the exception paths actually work end to end. A structured pass over roles × states × journeys is what catches the gaps that unit-level review misses.
+                      Design QA in an operational product means verifying the workflow, not just the
+                      pixels: does each role see what they should, do state transitions behave at
+                      every decision point, do the exception paths actually work end to end. A
+                      structured pass over roles × states × journeys is what catches the gaps that
+                      unit-level review misses.
                     </p>
                   }
                 />
@@ -357,9 +403,9 @@ const OperationsPlatformCase = () => (
                   content={
                     <ArtifactPlaceholder
                       className={pStyle}
-                      title={'QA approach'}
+                      title={"QA approach"}
                       prompt={
-                        'TODO: Insert the anonymized QA checklist or matrix used: journeys × roles × states, exception paths, and an example of a real gap it caught before release.'
+                        "TODO: Insert the anonymized QA checklist or matrix used: journeys × roles × states, exception paths, and an example of a real gap it caught before release."
                       }
                     />
                   }
@@ -369,20 +415,27 @@ const OperationsPlatformCase = () => (
           />
 
           <ProjectSection
-            title={'Outcome & learning'}
+            title={"Outcome & learning"}
             content={
               <span>
                 <Row
                   content={
                     <p className={pStyle}>
-                      Where hard metrics exist and can be shared, they belong here. Where they cannot, honest proxy evidence carries the case: workflows that moved fully into the product, handoffs that no longer depend on individual memory, and a structure that new journeys can be added to without redesigning the core. Those are verifiable claims about the work itself — no adoption numbers or business results will be invented to decorate them.
+                      Where hard metrics exist and can be shared, they belong here. Where they
+                      cannot, honest proxy evidence carries the case: workflows that moved fully
+                      into the product, handoffs that no longer depend on individual memory, and a
+                      structure that new journeys can be added to without redesigning the core.
+                      Those are verifiable claims about the work itself — no adoption numbers or
+                      business results will be invented to decorate them.
                     </p>
                   }
                 />
                 <Row
                   content={
                     <TbdNote className={pStyle}>
-                      TODO: Documented outcomes — measured where real and cleared for sharing, structural proxy evidence otherwise — plus an honest reflection on what worked, what was harder than expected, and what would change next time.
+                      TODO: Documented outcomes — measured where real and cleared for sharing,
+                      structural proxy evidence otherwise — plus an honest reflection on what
+                      worked, what was harder than expected, and what would change next time.
                     </TbdNote>
                   }
                 />


### PR DESCRIPTION
### Motivation

- The repository's format check was failing and causing the build action to error, so Prettier was applied to restore a consistent code style across source files and tests.

### Description

- Applied Prettier formatting to source UI pages, shared components, design-system modules, and affected Jest tests (14 files including `pages/design-system.js`, `pages/ai-decision-support.js`, `components/WritingCloudBackground.js`, and `components/design-system/CraftDetail.js`).
- Changes are purely stylistic: quote normalization, line-wrapping, trailing commas, and minor whitespace/parentheses reflow with no behavioral changes to logic.
- Updated a small set of test files so `prettier --check .` passes without modifying test intent.

### Testing

- Ran `npm run format:check` which passed and reported "All matched files use Prettier code style".
- Ran `npm test` which passed (27 test suites, 84 tests total).
- Ran `npm run build` which completed successfully and generated the static export without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5be7d18ed48330a438c5248e33e978)